### PR TITLE
Correct tags to use underscores

### DIFF
--- a/test_vmsgen.py
+++ b/test_vmsgen.py
@@ -1,0 +1,21 @@
+import vmsgen
+
+def test_tags_generation_from_none():
+    expected = []
+    actual = vmsgen.tags_from_service_name(None)
+    assert expected == actual
+
+def test_tags_generation_from_nonstring():
+    expected = []
+    actual = vmsgen.tags_from_service_name(1)
+    assert expected == actual
+
+def test_tags_generation_from_short_name():
+    expected = ['']
+    actual = vmsgen.tags_from_service_name('three.levels.deep')
+    assert expected == actual
+
+def test_tags_generation_from_proper_name():
+    expected = ['levels_deep']
+    actual = vmsgen.tags_from_service_name('more.than.three.levels.deep')
+    assert expected == actual

--- a/vmsgen.py
+++ b/vmsgen.py
@@ -418,6 +418,11 @@ def post_process_path(path_obj):
                             'description': 'Custom header to protect against CSRF attacks in browser based clients'}
         path_obj['parameters'] = [header_parameter]
 
+def tags_from_service_name(service_name):
+    if isinstance(service_name, str):
+        return ['_'.join(service_name.split('.')[3:])]
+    else:
+        return []
 
 def build_path(service_name, method, path, documentation, parameters, operation_id, responses, consumes,
                produces):
@@ -434,16 +439,7 @@ def build_path(service_name, method, path, documentation, parameters, operation_
     :return: swagger path object.
     """
     path_obj = {}
-    if service_name is not None:
-
-        splits = service_name.split('.')
-        splits = splits[3:]
-        tag = ''
-        for split in splits:
-            # todo:
-            # Need to add space here, otherwise swagger-ui breaks. figure out why.
-            tag += split + '/'
-        path_obj['tags'] = [tag[0:len(tag) - 1] + ' ']
+    path_obj['tags'] = tags_from_service_name(service_name)
     if method is not None:
         path_obj['method'] = method
     if path is not None:


### PR DESCRIPTION
Corrected tags to use underscores rather than forward slashes. This
fixes issues with code generation.

Signed-off-by: J.R. Garcia <jrg@vmware.com>