### PR TITLE
Set default host to '<vcenter>'

### DIFF
--- a/vmsgen.py
+++ b/vmsgen.py
@@ -500,7 +500,7 @@ def process_output(path_dict, type_dict, output_dir, output_filename):
                         'info': {'description': description_map.get(output_filename, ''),
                                  'title': output_filename,
                                  'termsOfService': 'http://swagger.io/terms/',
-                                 'version': '2.0.0'}, 'host': '',
+                                 'version': '2.0.0'}, 'host': '<vcenter>',
                         'basePath': '/rest', 'tags': [],
                         'schemes': ['https', 'http'],
                         'paths': collections.OrderedDict(sorted(path_dict.items())),


### PR DESCRIPTION
When the default host is set to an empty string, the documentation
generated for the clients show the URL to call as `https:///rest`
which is a bit confusing. This would cause the generated documentation
to show `https://<vcenter>/api` which looks a bit more appropriate.

Signed-off-by: J.R. Garcia <jrg@vmware.com>