### PR TITLE
Set to default error when error model not found

### DIFF
--- a/vmsgen.py
+++ b/vmsgen.py
@@ -398,7 +398,7 @@ def populate_response_map(output, errors, error_map, type_dict, structure_svc, e
     # hardcode it for now.
     response_map[requests.codes.ok] = success_response
     for error in errors:
-        status_code = error_map[error.structure_id]
+        status_code = error_map.get(error.structure_id, http_client.INTERNAL_SERVER_ERROR)
         check_type('com.vmware.vapi.structure', error.structure_id, type_dict, structure_svc, enum_svc)
         schema_obj = {'type': 'object', 'properties': {'type': {'type': 'string'},
                                                        'value': {'$ref': '#/definitions/' + error.structure_id}}}


### PR DESCRIPTION
When the error models status code can't be found (because that error
model has not been added yet), default to an INTERNAL SERVER ERROR or
500. This prevents us from raising an error rather than just returning
a 500 which is what vAPI will do.