### PR TITLE
Fix issue with tag generation

### DIFF
--- a/test_vmsgen.py
+++ b/test_vmsgen.py
@@ -1,15 +1,5 @@
 import vmsgen
 
-def test_tags_generation_from_none():
-    expected = []
-    actual = vmsgen.tags_from_service_name(None)
-    assert expected == actual
-
-def test_tags_generation_from_nonstring():
-    expected = []
-    actual = vmsgen.tags_from_service_name(1)
-    assert expected == actual
-
 def test_tags_generation_from_short_name():
     expected = ['']
     actual = vmsgen.tags_from_service_name('three.levels.deep')

--- a/vmsgen.py
+++ b/vmsgen.py
@@ -418,10 +418,7 @@ def post_process_path(path_obj):
         path_obj['parameters'] = [header_parameter]
 
 def tags_from_service_name(service_name):
-    if isinstance(service_name, six.string_types):
-        return ['_'.join(service_name.split('.')[3:])]
-    else:
-        return []
+    return ['_'.join(service_name.split('.')[3:])]
 
 def build_path(service_name, method, path, documentation, parameters, operation_id, responses, consumes,
                produces):


### PR DESCRIPTION
Currently, with Python 2, tag generation is broken because it checks for
instances of str and the string types between Python 2 and 3 had major
backwards-incompatible changes. This uses six to alleviate that issue.

Fixes #17