### PR TITLE
Add option for tag separator

### DIFF
--- a/test_vmsgen.py
+++ b/test_vmsgen.py
@@ -38,3 +38,17 @@ def test_tag_separator_option(monkeypatch):
         m.setattr(sys, 'argv', ['a', '-vc', 'b', '-o', 'c', '-s', expected])
         _, _, _, actual, _ = vmsgen.get_input_params()
         assert expected == actual
+
+def test_default_ssl_security_option(monkeypatch):
+    with monkeypatch.context() as m:
+         expected = True
+         m.setattr(sys, 'argv', ['a', '-vc', 'b'])
+         _, _, _, _, actual = vmsgen.get_input_params()
+         assert expected == actual
+
+def test_setting_insecure_ssl_security_option(monkeypatch):
+    with monkeypatch.context() as m:
+         expected = False
+         m.setattr(sys, 'argv', ['a', '-vc', 'b', '-k'])
+         _, _, _, _, actual = vmsgen.get_input_params()
+         assert expected == actual

--- a/vmsgen.py
+++ b/vmsgen.py
@@ -880,6 +880,7 @@ def get_input_params():
                         help='Output directory of swagger.json file. if not specified, current working directory is chosen as output directory')
     parser.add_argument('-k', '--insecure', action='store_true', help='Bypass SSL certificate validation')
     parser.add_argument('-s', '--tag-separator', default='/', help='Separator to use in tag name')
+    parser.add_argument('-k', '--insecure', action='store_true', help='Bypass SSL certificate validation')
     args = parser.parse_args()
     metadata_url = args.metadata_url
     rest_navigation_url = args.rest_navigation_url


### PR DESCRIPTION
Added option to CLI for tag seperator so that we could use the default
for the API Explorer and pass in an optional separator for use with code
generation for bindings.