### PR TITLE
Mark required fields properly

### DIFF
--- a/vmsgen.py
+++ b/vmsgen.py
@@ -183,6 +183,7 @@ def visit_type_category(struct_type, new_prop, type_dict, structure_svc, enum_sv
 
 
 def visit_type_category_dict(struct_type, new_prop, type_dict, structure_svc, enum_svc):
+    new_prop['required'] = True
     if struct_type['category'] == 'BUILTIN':
         visit_builtin(struct_type['builtin_type'], new_prop)
     elif struct_type['category'] == 'GENERIC':


### PR DESCRIPTION
Currently, 'OPTIONAL' fields are marked as not required, but we don't
mark anything as required otherwise and you have to explicitly mark
things as required for openapi-generator to mark them as such in the
binding. This fixes that issue by marking everything as required and
then marking it as not required if it is 'OPTIONAL'.