### PR TITLE
Add produces and consumes at root

### DIFF
--- a/vmsgen.py
+++ b/vmsgen.py
@@ -751,6 +751,8 @@ def process_output(path_dict, type_dict, output_dir, output_filename):
                             'basic_auth': {'type': 'basic'},
                             'api_key': {'type': 'apiKey', 'name': 'vmware-api-session-id', 'in': 'header'}},
                         "security": [{"api_key": []}],
+                        'consumes': ['application/json'],
+                        'produces': ['application/json'],
                         'basePath': '/rest', 'tags': [],
                         'schemes': ['https', 'http'],
                         'paths': collections.OrderedDict(sorted(path_dict.items())),


### PR DESCRIPTION
We don't specify what we produce at all ('application/json') or what we
consume at a root level. This allows us to have this specified for our
entire API.

I came across this when testing an OpenAPI mock server that takes an
OpenAPI spec and starts a mock server. When using it, it would never
correctly return anything because it didn't know what to produce.
With this commit, it will now return mock responses.