### PR TITLE
Change 'opaque' response type to 'object'

### DIFF
--- a/vmsgen.py
+++ b/vmsgen.py
@@ -161,6 +161,8 @@ def metamodel_to_swagger_type_converter(input_type):
         return 'string', 'password'
     if input_type == 'any_error':
         return 'string', None
+    if input_type == 'opaque':
+        return 'object', None
     if input_type == 'dynamic_structure':
         return 'object', None
     if input_type == 'uri':


### PR DESCRIPTION
An API response that returned an 'opaque' had caused some issues as that
is not a response type understood by the Swagger v2 spec. This now
responds with an "object" type in place of "opaque".

It isn't entirely accurate as the opaque type could return any type, but
the Swagger v2+ spec does not allow this. See [here](https://github.com/OAI/OpenAPI-Specification/issues/270) for more information on
this. The ability to have multiple response types for a single response code
has been added as a feature in OpenAPI v3+, but this currently uses the
Swagger v2 specification.

Signed-off-by: J.R. Garcia <jrg@vmware.com>