### PR TITLE
Add switch for deprecated rest APIs generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ The description of the input parameters that can go in the run command is as fol
 9. **host**: It is the IP Address of the host that serves the API. By default the value is < vcenter >
 10. **enable-filtering**: It is used to filter out internal and unrealeased API's so that if service info of the API is still under modification, it is skipped for processing.
 11. **oas** : This parameter is used to specify as to which version of swagger file the user wants to generate. By default the generated files are of version 3 i.e openapi. If the user wants to generate the version 2 files, the parameter needs to be passed explicitly.
+12. **mixed** : This parameter is used to specify whether deprecated APIs are going to be generated. By default the generated files do not contain information regarding the deprecated "/rest" APIs. If the user wants that information to be apparent in the generated files, then the parameter needs to be passed.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ The description of the input parameters that can go in the run command is as fol
 8. **metamodel-components**: If this parameter is passed, then each metamodel component retreived from the vCenter server is saved in a different .json file under the metamodel directory.
 9. **host**: It is the IP Address of the host that serves the API. By default the value is < vcenter >
 10. **oas** : This parameter is used to specify as to which version of swagger file the user wants to generate. By default the generated files are of version 3 i.e openapi. If the user wants to generate the version 2 files, the parameter needs to be passed explicitly.
-11. **mixed** : This parameter is used to specify whether deprecated APIs are going to be generated. By default the generated files do not contain information regarding the deprecated "/rest" APIs. If the user wants that information to be apparent in the generated files, then the parameter needs to be passed.
+11. **deprecate-slash-rest** : This parameter is used to deprecate the /rest APIs in the generated OpenAPI specification, only when the API to deprecate has an /api counterpart.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -40,9 +40,8 @@ The description of the input parameters that can go in the run command is as fol
 7. **unique-operation-ids**: This parameter is passed to generate unique ids for all operation/functions. Default value of this parameter is false. A required semantic rule of the open api specification is that the operations should have a unique operation name even if they are under different paths. If this parameter is ignored the generated swagger file may throw semantic error if it fails the openapi validation.
 8. **metamodel-components**: If this parameter is passed, then each metamodel component retreived from the vCenter server is saved in a different .json file under the metamodel directory.
 9. **host**: It is the IP Address of the host that serves the API. By default the value is < vcenter >
-10. **enable-filtering**: It is used to filter out internal and unrealeased API's so that if service info of the API is still under modification, it is skipped for processing.
-11. **oas** : This parameter is used to specify as to which version of swagger file the user wants to generate. By default the generated files are of version 3 i.e openapi. If the user wants to generate the version 2 files, the parameter needs to be passed explicitly.
-12. **mixed** : This parameter is used to specify whether deprecated APIs are going to be generated. By default the generated files do not contain information regarding the deprecated "/rest" APIs. If the user wants that information to be apparent in the generated files, then the parameter needs to be passed.
+10. **oas** : This parameter is used to specify as to which version of swagger file the user wants to generate. By default the generated files are of version 3 i.e openapi. If the user wants to generate the version 2 files, the parameter needs to be passed explicitly.
+11. **mixed** : This parameter is used to specify whether deprecated APIs are going to be generated. By default the generated files do not contain information regarding the deprecated "/rest" APIs. If the user wants that information to be apparent in the generated files, then the parameter needs to be passed.
 
 ## Contributing
 

--- a/lib/api_endpoint/api_metamodel2spec.py
+++ b/lib/api_endpoint/api_metamodel2spec.py
@@ -14,7 +14,7 @@ class ApiMetamodel2Spec():
             enum_dict,
             operation_id,
             error_map,
-            enable_filtering):
+            show_unreleased_apis):
         pass
 
     def handle_request_mapping(
@@ -27,7 +27,7 @@ class ApiMetamodel2Spec():
             type_dict,
             structure_svc,
             enum_svc,
-            enable_filtering,
+            show_unreleased_apis,
             spec):
         if method_type in ('post', 'put', 'patch'):
             return self.process_put_post_patch_request(
@@ -38,7 +38,7 @@ class ApiMetamodel2Spec():
                 type_dict,
                 structure_svc,
                 enum_svc,
-                enable_filtering,
+                show_unreleased_apis,
                 spec)
         if method_type == 'get':
             return self.process_get_request(
@@ -47,7 +47,7 @@ class ApiMetamodel2Spec():
                 type_dict,
                 structure_svc,
                 enum_svc,
-                enable_filtering,
+                show_unreleased_apis,
                 spec)
         if method_type == 'delete':
             return self.process_delete_request(
@@ -56,7 +56,7 @@ class ApiMetamodel2Spec():
                 type_dict,
                 structure_svc,
                 enum_svc,
-                enable_filtering,
+                show_unreleased_apis,
                 spec)
 
     def process_put_post_patch_request(
@@ -68,7 +68,7 @@ class ApiMetamodel2Spec():
             type_dict,
             structure_svc,
             enum_svc,
-            enable_filtering,
+            show_unreleased_apis,
             spec):
         """
         Handles http post/put/patch request.
@@ -80,7 +80,7 @@ class ApiMetamodel2Spec():
         par_array = []
         for field_info in path_param_list:
             parx = spec.convert_field_info_to_swagger_parameter(
-                'path', field_info, type_dict, structure_svc, enum_svc, enable_filtering)
+                'path', field_info, type_dict, structure_svc, enum_svc, show_unreleased_apis)
             par_array.append(parx)
 
         # Body
@@ -95,7 +95,7 @@ class ApiMetamodel2Spec():
                 type_dict,
                 structure_svc,
                 enum_svc,
-                enable_filtering)
+                show_unreleased_apis)
             if parx is not None:
                 par_array.append(parx)
 
@@ -104,7 +104,7 @@ class ApiMetamodel2Spec():
             other_param_list)
         for query_param in query_param_list:
             parx = spec.convert_field_info_to_swagger_parameter(
-                'query', query_param, type_dict, structure_svc, enum_svc, enable_filtering)
+                'query', query_param, type_dict, structure_svc, enum_svc, show_unreleased_apis)
             par_array.append(parx)
 
         # process query parameters
@@ -113,7 +113,7 @@ class ApiMetamodel2Spec():
             # handling of all the query parameters; filter as well as non
             # filter
             flattened_params = spec.flatten_query_param_spec(
-                field_info, type_dict, structure_svc, enum_svc, enable_filtering)
+                field_info, type_dict, structure_svc, enum_svc, show_unreleased_apis)
             if flattened_params is not None:
                 par_array = par_array + flattened_params
 
@@ -126,7 +126,7 @@ class ApiMetamodel2Spec():
             type_dict,
             structure_svc,
             enum_svc,
-            enable_filtering,
+            show_unreleased_apis,
             spec):
         param_array = []
         path_param_list, other_params_list, new_url = utils.extract_path_parameters(
@@ -134,7 +134,7 @@ class ApiMetamodel2Spec():
 
         for field_info in path_param_list:
             parameter_obj = spec.convert_field_info_to_swagger_parameter(
-                'path', field_info, type_dict, structure_svc, enum_svc, enable_filtering)
+                'path', field_info, type_dict, structure_svc, enum_svc, show_unreleased_apis)
             param_array.append(parameter_obj)
 
         query_param_list, other_params_list = utils.extract_query_parameters(
@@ -142,7 +142,7 @@ class ApiMetamodel2Spec():
         # Query
         for query_param in query_param_list:
             parameter_obj = spec.convert_field_info_to_swagger_parameter(
-                'query', query_param, type_dict, structure_svc, enum_svc, enable_filtering)
+                'query', query_param, type_dict, structure_svc, enum_svc, show_unreleased_apis)
             param_array.append(parameter_obj)
 
         # process query parameters
@@ -151,7 +151,7 @@ class ApiMetamodel2Spec():
             # handling of all the query parameters; filter as well as non
             # filter
             flattened_params = spec.flatten_query_param_spec(
-                field_info, type_dict, structure_svc, enum_svc, enable_filtering)
+                field_info, type_dict, structure_svc, enum_svc, show_unreleased_apis)
             if flattened_params is not None:
                 param_array = param_array + flattened_params
         return param_array, new_url
@@ -163,18 +163,18 @@ class ApiMetamodel2Spec():
             type_dict,
             structure_svc,
             enum_svc,
-            enable_filtering,
+            show_unreleased_apis,
             spec):
         path_param_list, other_params, new_url = utils.extract_path_parameters(
             params, url)
         param_array = []
         for field_info in path_param_list:
             parx = spec.convert_field_info_to_swagger_parameter(
-                'path', field_info, type_dict, structure_svc, enum_svc, enable_filtering)
+                'path', field_info, type_dict, structure_svc, enum_svc, show_unreleased_apis)
             param_array.append(parx)
         for field_info in other_params:
             parx = spec.convert_field_info_to_swagger_parameter(
-                'query', field_info, type_dict, structure_svc, enum_svc, enable_filtering)
+                'query', field_info, type_dict, structure_svc, enum_svc, show_unreleased_apis)
             param_array.append(parx)
         return param_array, new_url
 

--- a/lib/api_endpoint/api_type_handler.py
+++ b/lib/api_endpoint/api_type_handler.py
@@ -4,6 +4,9 @@ from lib.type_handler_common import TypeHandlerCommon
 
 class ApiTypeHandler(TypeHandlerCommon):
 
+    def __init__(self, show_unreleased_apis):
+        TypeHandlerCommon.__init__(self, show_unreleased_apis)
+
     def visit_generic(
             self,
             generic_instantiation,
@@ -11,8 +14,7 @@ class ApiTypeHandler(TypeHandlerCommon):
             type_dict,
             structure_svc,
             enum_svc,
-            ref_path,
-            enable_filtering):
+            ref_path):
         if generic_instantiation.generic_type == 'OPTIONAL':
             new_prop['required'] = False
             self.visit_type_category(
@@ -21,8 +23,7 @@ class ApiTypeHandler(TypeHandlerCommon):
                 type_dict,
                 structure_svc,
                 enum_svc,
-                ref_path,
-                enable_filtering)
+                ref_path)
         elif generic_instantiation.generic_type == 'LIST':
             new_prop['type'] = 'array'
             self.visit_type_category(
@@ -31,8 +32,7 @@ class ApiTypeHandler(TypeHandlerCommon):
                 type_dict,
                 structure_svc,
                 enum_svc,
-                ref_path,
-                enable_filtering)
+                ref_path)
         elif generic_instantiation.generic_type == 'SET':
             new_prop['type'] = 'array'
             new_prop['uniqueItems'] = True
@@ -42,8 +42,7 @@ class ApiTypeHandler(TypeHandlerCommon):
                 type_dict,
                 structure_svc,
                 enum_svc,
-                ref_path,
-                enable_filtering)
+                ref_path)
         elif generic_instantiation.generic_type == 'MAP':
             # Have static key/value pair object maping for /rest paths
             # while use additionalProperties for /api paths
@@ -60,8 +59,7 @@ class ApiTypeHandler(TypeHandlerCommon):
                     type_dict,
                     structure_svc,
                     enum_svc,
-                    ref_path,
-                    enable_filtering)
+                    ref_path)
 
             elif generic_instantiation.map_value_type.category == 'BUILTIN':
                 new_type['additionalProperties'] = {
@@ -76,8 +74,7 @@ class ApiTypeHandler(TypeHandlerCommon):
                     type_dict,
                     structure_svc,
                     enum_svc,
-                    ref_path,
-                    enable_filtering)
+                    ref_path)
                 new_type['additionalProperties'] = temp_new_type
 
             new_prop.update(new_type)

--- a/lib/api_endpoint/api_url_processing.py
+++ b/lib/api_endpoint/api_url_processing.py
@@ -31,7 +31,7 @@ class ApiUrlProcessing(UrlProcessing):
             service_dict,
             service_url_dict,
             http_error_map,
-            enable_filtering,
+            show_unreleased_apis,
             spec,
             gen_unique_op_id):
 
@@ -44,7 +44,7 @@ class ApiUrlProcessing(UrlProcessing):
             service_info = service_dict.get(service_name, None)
             if service_info is None:
                 continue
-            if utils.is_filtered(service_info.metadata, enable_filtering):
+            if (not show_unreleased_apis) and utils.is_filtered(service_info.metadata):
                 continue
             for operation_id, operation_info in service_info.operations.items():
 
@@ -73,7 +73,7 @@ class ApiUrlProcessing(UrlProcessing):
                         enum_dict,
                         operation_id,
                         http_error_map,
-                        enable_filtering)
+                        show_unreleased_apis)
                 if spec == '3':
                     path = openapi.get_path(
                         operation_info,
@@ -85,7 +85,7 @@ class ApiUrlProcessing(UrlProcessing):
                         enum_dict,
                         operation_id,
                         http_error_map,
-                        enable_filtering)
+                        show_unreleased_apis)
 
                 path_list.append(path)
             continue

--- a/lib/api_endpoint/api_url_processing.py
+++ b/lib/api_endpoint/api_url_processing.py
@@ -48,12 +48,9 @@ class ApiUrlProcessing(UrlProcessing):
                 continue
             for operation_id, operation_info in service_info.operations.items():
 
-                try:
-                    method, url = self.api_get_url_and_method(
-                        operation_info.metadata)
-                except TypeError as ex:
-                    eprint('Operation is not @VERB annotated %s - %s' % (operation_id, service_url))
-                    eprint(ex)
+                method, url = self.api_get_url_and_method(
+                    operation_info.metadata)
+                if method is None or url is None:
                     continue
 
                 # check for query parameters
@@ -113,3 +110,4 @@ class ApiUrlProcessing(UrlProcessing):
             if method in ['POST', 'GET', 'DELETE', 'PUT', 'PATCH']:
                 url_path = metadata[method].elements["path"].string_value
                 return method, url_path
+        return None, None

--- a/lib/api_endpoint/api_url_processing.py
+++ b/lib/api_endpoint/api_url_processing.py
@@ -1,4 +1,6 @@
 import os
+import threading
+
 import six
 from lib import utils
 from lib.url_processing import UrlProcessing
@@ -6,6 +8,7 @@ from .oas3.api_metamodel2openapi import ApiMetamodel2Openapi
 from .swagger2.api_metamodel2swagger import ApiMetamodel2Swagger
 from .oas3.api_openapi_final_path_processing import ApiOpenapiPathProcessing
 from .swagger2.api_swagger_final_path_processing import ApiSwaggerPathProcessing
+from ..utils import eprint
 
 api_openapi_fpp = ApiOpenapiPathProcessing()
 api_swagg_fpp = ApiSwaggerPathProcessing()
@@ -28,7 +31,6 @@ class ApiUrlProcessing(UrlProcessing):
             service_dict,
             service_url_dict,
             http_error_map,
-            rest_navigation_url,
             enable_filtering,
             spec,
             gen_unique_op_id):
@@ -45,8 +47,14 @@ class ApiUrlProcessing(UrlProcessing):
             if utils.is_filtered(service_info.metadata, enable_filtering):
                 continue
             for operation_id, operation_info in service_info.operations.items():
-                method, url = self.api_get_url_and_method(
-                    operation_info.metadata)
+
+                try:
+                    method, url = self.api_get_url_and_method(
+                        operation_info.metadata)
+                except TypeError as ex:
+                    eprint('Operation is not @VERB annotated %s - %s' % (operation_id, service_url))
+                    eprint(ex)
+                    continue
 
                 # check for query parameters
                 if 'params' in operation_info.metadata[method].elements:

--- a/lib/api_endpoint/oas3/api_metamodel2openapi.py
+++ b/lib/api_endpoint/oas3/api_metamodel2openapi.py
@@ -19,7 +19,7 @@ class ApiMetamodel2Openapi(ApiMetamodel2Spec):
             enum_dict,
             operation_id,
             http_error_map,
-            enable_filtering):
+            show_unreleased_apis):
         documentation = operation_info.documentation
         op_metadata = operation_info.metadata
         params = operation_info.params
@@ -28,7 +28,7 @@ class ApiMetamodel2Openapi(ApiMetamodel2Spec):
         http_method = http_method.lower()
         par_array, url = self.handle_request_mapping(url, http_method, service_name,
                                                      operation_id, params, type_dict,
-                                                     structure_dict, enum_dict, enable_filtering, api_open_ph)
+                                                     structure_dict, enum_dict, show_unreleased_apis, api_open_ph)
         response_map = api_open_rh.populate_response_map(
             output,
             errors,
@@ -39,7 +39,7 @@ class ApiMetamodel2Openapi(ApiMetamodel2Spec):
             service_name,
             operation_id,
             op_metadata,
-            enable_filtering)
+            show_unreleased_apis)
 
         path_obj = utils.build_path(
             service_name,

--- a/lib/api_endpoint/oas3/api_openapi_final_path_processing.py
+++ b/lib/api_endpoint/oas3/api_openapi_final_path_processing.py
@@ -117,15 +117,25 @@ class ApiOpenapiPathProcessing(PathProcessing):
                 query_param = []
                 for query_parameter in paths_array[1].split('&'):
                     key_value = query_parameter.split('=')
-                    q_param = {
-                        'name': key_value[0],
-                        'in': 'query',
-                        'description': key_value[0] + '=' + key_value[1],
-                        'required': True}
-                    q_param['schema'] = {}
-                    q_param['schema']['type'] = 'string'
-                    q_param['schema']['enum'] = [key_value[1]]
-                    query_param.append(q_param)
+                    if len(key_value) == 2:
+                        q_param = {
+                            'name': key_value[0],
+                            'in': 'query',
+                            'description': key_value[0] + '=' + key_value[1],
+                            'required': True}
+                        q_param['schema'] = {}
+                        q_param['schema']['type'] = 'string'
+                        q_param['schema']['enum'] = [key_value[1]]
+                        query_param.append(q_param)
+                    else:
+                        q_param = {
+                            'name': key_value[0],
+                            'in': 'query',
+                            'description': key_value[0],
+                            'required': True}
+                        q_param['schema'] = {}
+                        q_param['schema']['type'] = 'string'
+                        query_param.append(q_param)
 
                 if new_path in path_dict:
                     new_path_operations = path_dict[new_path].keys()

--- a/lib/api_endpoint/oas3/api_openapi_final_path_processing.py
+++ b/lib/api_endpoint/oas3/api_openapi_final_path_processing.py
@@ -117,25 +117,14 @@ class ApiOpenapiPathProcessing(PathProcessing):
                 query_param = []
                 for query_parameter in paths_array[1].split('&'):
                     key_value = query_parameter.split('=')
+                    q_param = {'name': key_value[0], 'in': 'query', 'required': True, 'schema': {}}
+                    q_param['schema']['type'] = 'string'
                     if len(key_value) == 2:
-                        q_param = {
-                            'name': key_value[0],
-                            'in': 'query',
-                            'description': key_value[0] + '=' + key_value[1],
-                            'required': True}
-                        q_param['schema'] = {}
-                        q_param['schema']['type'] = 'string'
+                        q_param['description'] = key_value[0] + '=' + key_value[1]
                         q_param['schema']['enum'] = [key_value[1]]
-                        query_param.append(q_param)
                     else:
-                        q_param = {
-                            'name': key_value[0],
-                            'in': 'query',
-                            'description': key_value[0],
-                            'required': True}
-                        q_param['schema'] = {}
-                        q_param['schema']['type'] = 'string'
-                        query_param.append(q_param)
+                        q_param['description'] = key_value[0]
+                    query_param.append(q_param)
 
                 if new_path in path_dict:
                     new_path_operations = path_dict[new_path].keys()

--- a/lib/api_endpoint/oas3/api_openapi_final_path_processing.py
+++ b/lib/api_endpoint/oas3/api_openapi_final_path_processing.py
@@ -52,7 +52,7 @@ class ApiOpenapiPathProcessing(PathProcessing):
         utils.write_json_data_to_file(
             output_dir +
             os.path.sep +
-            '/api' +
+            'api' +
             "_" +
             utils.remove_curly_braces(output_filename) +
             '.json',
@@ -117,13 +117,15 @@ class ApiOpenapiPathProcessing(PathProcessing):
                 query_param = []
                 for query_parameter in paths_array[1].split('&'):
                     key_value = query_parameter.split('=')
-                    q_param = {'name': key_value[0], 'in': 'query', 'required': True, 'schema': {}}
-                    q_param['schema']['type'] = 'string'
+                    q_param = {'name': key_value[0],
+                               'in': 'query',
+                               'description': key_value[0],
+                               'required': True,
+                               'schema': {'type': 'string'}
+                               }
                     if len(key_value) == 2:
                         q_param['description'] = key_value[0] + '=' + key_value[1]
                         q_param['schema']['enum'] = [key_value[1]]
-                    else:
-                        q_param['description'] = key_value[0]
                     query_param.append(q_param)
 
                 if new_path in path_dict:

--- a/lib/api_endpoint/oas3/api_openapi_parameter_handler.py
+++ b/lib/api_endpoint/oas3/api_openapi_parameter_handler.py
@@ -1,6 +1,4 @@
-import re
 import six
-from lib import utils
 from lib.api_endpoint.api_type_handler import ApiTypeHandler
 
 
@@ -13,21 +11,20 @@ class ApiOpenapiParaHandler():
             type_dict,
             structure_svc,
             enum_svc,
-            enable_filtering):
+            show_unreleased_apis):
         """
         Converts metamodel fieldinfo to swagger parameter.
         """
         parameter_obj = {}
         ref_path = "#/components/schemas/"
-        tpHandler = ApiTypeHandler()
+        tpHandler = ApiTypeHandler(show_unreleased_apis)
         tpHandler.visit_type_category(
             input_parameter_obj.type,
             parameter_obj,
             type_dict,
             structure_svc,
             enum_svc,
-            ref_path,
-            enable_filtering)
+            ref_path)
         if 'required' not in parameter_obj:
             parameter_obj['required'] = True
         parameter_obj['in'] = param_type
@@ -62,7 +59,7 @@ class ApiOpenapiParaHandler():
             type_dict,
             structure_svc,
             enum_svc,
-            enable_filtering):
+            show_unreleased_apis):
         """
         Creates a  json object wrapper around request body parameters. parameter names are used as keys and the
         parameters as values.
@@ -79,7 +76,7 @@ class ApiOpenapiParaHandler():
         properties_obj = {}
         required = []
         ref_path = "#/components/schemas/"
-        tpHandler = ApiTypeHandler()
+        tpHandler = ApiTypeHandler(show_unreleased_apis)
         for param in body_param_list:
             parameter_obj = {}
             tpHandler.visit_type_category(
@@ -88,8 +85,7 @@ class ApiOpenapiParaHandler():
                 type_dict,
                 structure_svc,
                 enum_svc,
-                ref_path,
-                enable_filtering)
+                ref_path)
             parameter_obj['description'] = param.documentation
             body_obj.update(parameter_obj)
 
@@ -115,7 +111,7 @@ class ApiOpenapiParaHandler():
             type_dict,
             structure_svc,
             enum_svc,
-            enable_filtering):
+            show_unreleased_apis):
         """
         Flattens query parameters specs.
         1. Create a query parameter for every field in spec.
@@ -152,15 +148,14 @@ class ApiOpenapiParaHandler():
         prop_array = []
         parameter_obj = {}
         ref_path = "#/components/schemas/"
-        tpHandler = ApiTypeHandler()
+        tpHandler = ApiTypeHandler(show_unreleased_apis)
         tpHandler.visit_type_category(
             query_param_info.type,
             parameter_obj,
             type_dict,
             structure_svc,
             enum_svc,
-            ref_path,
-            enable_filtering)
+            ref_path)
         if '$ref' in parameter_obj:
             reference = parameter_obj['$ref'].replace(ref_path, '')
             type_ref = type_dict.get(reference, None)

--- a/lib/api_endpoint/oas3/api_openapi_response_handler.py
+++ b/lib/api_endpoint/oas3/api_openapi_response_handler.py
@@ -16,7 +16,7 @@ class ApiOpenapiRespHandler():
             service_id,
             operation_id,
             op_metadata,
-            enable_filtering):
+            show_unreleased_apis):
 
         response_map = {}
         ref_path = "#/components/schemas/"
@@ -28,15 +28,14 @@ class ApiOpenapiRespHandler():
             }
         }
         schema = {}
-        tpHandler = ApiTypeHandler()
+        tpHandler = ApiTypeHandler(show_unreleased_apis)
         tpHandler.visit_type_category(
             output.type,
             schema,
             type_dict,
             structure_svc,
             enum_svc,
-            ref_path,
-            enable_filtering)
+            ref_path)
         # if type of schema is void, don't include it.
         # this prevents showing response as void in swagger-ui
         if schema is not None:
@@ -60,8 +59,7 @@ class ApiOpenapiRespHandler():
                 type_dict,
                 structure_svc,
                 enum_svc,
-                ref_path,
-                enable_filtering)
+                ref_path)
             response_obj = {
                 'description': error.documentation,
                 'content': {

--- a/lib/api_endpoint/swagger2/api_metamodel2swagger.py
+++ b/lib/api_endpoint/swagger2/api_metamodel2swagger.py
@@ -19,7 +19,7 @@ class ApiMetamodel2Swagger(ApiMetamodel2Spec):
             enum_dict,
             operation_id,
             http_error_map,
-            enable_filtering):
+            show_unreleased_apis):
         documentation = operation_info.documentation
         op_metadata = operation_info.metadata
         params = operation_info.params
@@ -28,7 +28,7 @@ class ApiMetamodel2Swagger(ApiMetamodel2Spec):
         http_method = http_method.lower()
         par_array, url = self.handle_request_mapping(url, http_method, service_name,
                                                      operation_id, params, type_dict,
-                                                     structure_dict, enum_dict, enable_filtering, api_swagg_ph)
+                                                     structure_dict, enum_dict, show_unreleased_apis, api_swagg_ph)
         response_map = api_swagg_rh.populate_response_map(
             output,
             errors,
@@ -39,7 +39,7 @@ class ApiMetamodel2Swagger(ApiMetamodel2Spec):
             service_name,
             operation_id,
             op_metadata,
-            enable_filtering)
+            show_unreleased_apis)
 
         path_obj = utils.build_path(
             service_name,

--- a/lib/api_endpoint/swagger2/api_metamodel2swagger.py
+++ b/lib/api_endpoint/swagger2/api_metamodel2swagger.py
@@ -26,8 +26,6 @@ class ApiMetamodel2Swagger(ApiMetamodel2Spec):
         errors = operation_info.errors
         output = operation_info.output
         http_method = http_method.lower()
-        consumes_json = self.find_consumes(http_method)
-        produces = None
         par_array, url = self.handle_request_mapping(url, http_method, service_name,
                                                      operation_id, params, type_dict,
                                                      structure_dict, enum_dict, enable_filtering, api_swagg_ph)
@@ -50,20 +48,10 @@ class ApiMetamodel2Swagger(ApiMetamodel2Spec):
             documentation,
             par_array,
             operation_id=operation_id,
-            responses=response_map,
-            consumes=consumes_json,
-            produces=produces)
+            responses=response_map)
         self.post_process_path(path_obj)
         path = utils.add_basic_auth(path_obj)
         return path
-
-    def find_consumes(self, method_type):
-        """
-        Determine mediaType for input parameters in request body.
-        """
-        if method_type in ('get', 'delete'):
-            return None
-        return ['application/json']
 
     def post_process_path(self, path_obj):
         # Temporary fixes necessary for generated spec files.

--- a/lib/api_endpoint/swagger2/api_swagger_final_path_processing.py
+++ b/lib/api_endpoint/swagger2/api_swagger_final_path_processing.py
@@ -117,14 +117,22 @@ class ApiSwaggerPathProcessing(PathProcessing):
                 query_param = []
                 for query_parameter in paths_array[1].split('&'):
                     key_value = query_parameter.split('=')
-                    q_param = {
-                        'name': key_value[0],
-                        'in': 'query',
-                        'description': key_value[0] + '=' + key_value[1],
-                        'required': True,
-                        'type': 'string',
-                        'enum': [
-                            key_value[1]]}
+                    if len(key_value) == 2:
+                        q_param = {
+                            'name': key_value[0],
+                            'in': 'query',
+                            'description': key_value[0] + '=' + key_value[1],
+                            'required': True,
+                            'type': 'string',
+                            'enum': [
+                                key_value[1]]}
+                    else:
+                        q_param = {
+                            'name': key_value[0],
+                            'in': 'query',
+                            'description': key_value[0],
+                            'required': True,
+                            'type': 'string'}
                     query_param.append(q_param)
 
                 if new_path in path_dict:

--- a/lib/api_endpoint/swagger2/api_swagger_final_path_processing.py
+++ b/lib/api_endpoint/swagger2/api_swagger_final_path_processing.py
@@ -35,6 +35,12 @@ class ApiSwaggerPathProcessing(PathProcessing):
                 'basic_auth': {
                     'type': 'basic'}},
             'basePath': '/api',
+            'produces': [
+                'application/json'
+            ],
+            "consumes": [
+                "application/json"
+            ],
             'tags': [],
             'schemes': [
                 'https',

--- a/lib/api_endpoint/swagger2/api_swagger_final_path_processing.py
+++ b/lib/api_endpoint/swagger2/api_swagger_final_path_processing.py
@@ -58,7 +58,7 @@ class ApiSwaggerPathProcessing(PathProcessing):
         utils.write_json_data_to_file(
             output_dir +
             os.path.sep +
-            '/api' +
+            'api' +
             "_" +
             utils.remove_curly_braces(output_filename) +
             '.json',
@@ -123,22 +123,16 @@ class ApiSwaggerPathProcessing(PathProcessing):
                 query_param = []
                 for query_parameter in paths_array[1].split('&'):
                     key_value = query_parameter.split('=')
+                    q_param = {
+                        'name': key_value[0],
+                        'in': 'query',
+                        'description': key_value[0],
+                        'required': True,
+                        'type': 'string'}
                     if len(key_value) == 2:
-                        q_param = {
-                            'name': key_value[0],
-                            'in': 'query',
-                            'description': key_value[0] + '=' + key_value[1],
-                            'required': True,
-                            'type': 'string',
-                            'enum': [
-                                key_value[1]]}
-                    else:
-                        q_param = {
-                            'name': key_value[0],
-                            'in': 'query',
-                            'description': key_value[0],
-                            'required': True,
-                            'type': 'string'}
+                        q_param['description'] = key_value[0] + '=' + key_value[1]
+                        q_param['enum'] = [key_value[1]]
+
                     query_param.append(q_param)
 
                 if new_path in path_dict:

--- a/lib/api_endpoint/swagger2/api_swagger_parameter_handler.py
+++ b/lib/api_endpoint/swagger2/api_swagger_parameter_handler.py
@@ -13,21 +13,20 @@ class ApiSwaggerParaHandler():
             type_dict,
             structure_svc,
             enum_svc,
-            enable_filtering):
+            show_unreleased_apis):
         """
         Converts metamodel fieldinfo to swagger parameter.
         """
         parameter_obj = {}
         ref_path = "#/definitions/"
-        tpHandler = ApiTypeHandler()
+        tpHandler = ApiTypeHandler(show_unreleased_apis)
         tpHandler.visit_type_category(
             input_parameter_obj.type,
             parameter_obj,
             type_dict,
             structure_svc,
             enum_svc,
-            ref_path,
-            enable_filtering)
+            ref_path)
         if 'required' not in parameter_obj:
             parameter_obj['required'] = True
         parameter_obj['in'] = param_type
@@ -56,7 +55,7 @@ class ApiSwaggerParaHandler():
             type_dict,
             structure_svc,
             enum_svc,
-            enable_filtering):
+            show_unreleased_apis):
         """
         Creates a  json object wrapper around request body parameters. parameter names are used as keys and the
         parameters as values.
@@ -73,7 +72,7 @@ class ApiSwaggerParaHandler():
         properties_obj = {}
         required = []
         ref_path = "#/definitions/"
-        tpHandler = ApiTypeHandler()
+        tpHandler = ApiTypeHandler(show_unreleased_apis)
         for param in body_param_list:
             parameter_obj = {}
             tpHandler.visit_type_category(
@@ -82,8 +81,7 @@ class ApiSwaggerParaHandler():
                 type_dict,
                 structure_svc,
                 enum_svc,
-                ref_path,
-                enable_filtering)
+                ref_path)
             parameter_obj['description'] = param.documentation
             body_obj.update(parameter_obj)
 
@@ -106,7 +104,7 @@ class ApiSwaggerParaHandler():
             type_dict,
             structure_svc,
             enum_svc,
-            enable_filtering):
+            show_unreleased_apis):
         """
         Flattens query parameters specs.
         1. Create a query parameter for every field in spec.
@@ -143,15 +141,14 @@ class ApiSwaggerParaHandler():
         prop_array = []
         parameter_obj = {}
         ref_path = "#/definitions/"
-        tpHandler = ApiTypeHandler()
+        tpHandler = ApiTypeHandler(show_unreleased_apis)
         tpHandler.visit_type_category(
             query_param_info.type,
             parameter_obj,
             type_dict,
             structure_svc,
             enum_svc,
-            ref_path,
-            enable_filtering)
+            ref_path)
         if '$ref' in parameter_obj:
             reference = parameter_obj['$ref'].replace(ref_path, '')
             type_ref = type_dict.get(reference, None)

--- a/lib/api_endpoint/swagger2/api_swagger_response_handler.py
+++ b/lib/api_endpoint/swagger2/api_swagger_response_handler.py
@@ -16,21 +16,20 @@ class ApiSwaggerRespHandler():
             service_id,
             operation_id,
             op_metadata,
-            enable_filtering):
+            show_unreleased_apis):
 
         response_map = {}
         ref_path = "#/definitions/"
         success_response = {'description': output.documentation}
         schema = {}
-        tpHandler = ApiTypeHandler()
+        tpHandler = ApiTypeHandler(show_unreleased_apis)
         tpHandler.visit_type_category(
             output.type,
             schema,
             type_dict,
             structure_svc,
             enum_svc,
-            ref_path,
-            enable_filtering)
+            ref_path)
         # if type of schema is void, don't include it.
         # this prevents showing response as void in swagger-ui
         if schema is not None:
@@ -54,8 +53,7 @@ class ApiSwaggerRespHandler():
                 type_dict,
                 structure_svc,
                 enum_svc,
-                ref_path,
-                enable_filtering)
+                ref_path)
             response_obj = {
                 'description': error.documentation, 'schema': {
                     '$ref': ref_path + error.structure_id}}

--- a/lib/blacklist_utils.py
+++ b/lib/blacklist_utils.py
@@ -6,9 +6,9 @@ blacklist = {"rest": ['com.vmware.vcenter.vm.compute.policies',
              "api": []}
 
 
-def isBlacklistedForRest(service):
+def is_blacklisted_for_rest(service):
     return service in blacklist["rest"]
 
 
-def isBlacklistedForApi(service):
+def is_blacklisted_for_api(service):
     return service in blacklist["api"]

--- a/lib/blacklist_utils.py
+++ b/lib/blacklist_utils.py
@@ -1,0 +1,14 @@
+blacklist = {"rest": ['com.vmware.vcenter.vm.compute.policies',
+                      'com.vmware.vcenter.compute.policies.tag_usage',
+                      'com.vmware.vcenter.compute.policies.VM',
+                      'com.vmware.vcenter.compute.policies.capabilities',
+                      'com.vmware.vcenter.compute.policies'],
+             "api": []}
+
+
+def isBlacklistedForRest(service):
+    return service in blacklist["rest"]
+
+
+def isBlacklistedForApi(service):
+    return service in blacklist["api"]

--- a/lib/dictionary_processing.py
+++ b/lib/dictionary_processing.py
@@ -120,8 +120,13 @@ def add_service_urls_using_metamodel(
         })
 
     for service in service_dict:
-        service_type, path_list = get_paths_inside_metamodel(service, service_dict, deprecate_rest, replacement_dict, rest_services.get(service, None), rest_navigation_handler)
-        if (service_type == ServiceType.SLASH_API or service_type == ServiceType.SLASH_REST_AND_API) and not blacklist_utils.isBlacklistedForApi(service):
+        service_type, path_list = get_paths_inside_metamodel(service,
+                                                             service_dict,
+                                                             deprecate_rest,
+                                                             replacement_dict,
+                                                             rest_services.get(service, None),
+                                                             rest_navigation_handler)
+        if (service_type in [ServiceType.SLASH_API, ServiceType.SLASH_REST_AND_API]) and not blacklist_utils.is_blacklisted_for_api(service):
             for path in path_list:
                 service_urls_map[path] = (service, '/api')
                 package_name = path.split('/')[1]
@@ -129,7 +134,7 @@ def add_service_urls_using_metamodel(
                 if pack_arr == []:
                     package_dict_api[package_name] = pack_arr
                 pack_arr.append(path)
-        elif service_type == ServiceType.SLASH_REST and not blacklist_utils.isBlacklistedForRest(service):
+        elif service_type == ServiceType.SLASH_REST and not blacklist_utils.is_blacklisted_for_rest(service):
             service_url = rest_services.get(service, None)
             if service_url is not None:
                 service_path = get_service_path_from_service_url(
@@ -143,7 +148,7 @@ def add_service_urls_using_metamodel(
                     package_dict.setdefault(package, [service_path])
             else:
                 print("Service does not belong to either /api or /rest ", service)
-        if service_type == ServiceType.SLASH_REST_AND_API and not blacklist_utils.isBlacklistedForRest(service):
+        if service_type == ServiceType.SLASH_REST_AND_API and not blacklist_utils.is_blacklisted_for_rest(service):
             service_url = rest_services.get(service, None)
             if service_url is not None:
                 service_path = get_service_path_from_service_url(

--- a/lib/dictionary_processing.py
+++ b/lib/dictionary_processing.py
@@ -1,11 +1,7 @@
-import json
 import os
-import requests
-import six
-from six.moves import http_client
-from lib import utils
-from enum import Enum
 
+from lib import utils
+from lib import blacklist_utils
 from lib.rest_endpoint.rest_navigation_handler import RestNavigationHandler
 
 
@@ -125,7 +121,7 @@ def add_service_urls_using_metamodel(
 
     for service in service_dict:
         service_type, path_list = get_paths_inside_metamodel(service, service_dict, mixed, replacement_map, rest_services.get(service, None), rest_navigation_handler)
-        if service_type == ServiceType.API or service_type == ServiceType.MIXED:
+        if (service_type == ServiceType.API or service_type == ServiceType.MIXED) and not blacklist_utils.isBlacklistedForApi(service):
             for path in path_list:
                 service_urls_map[path] = (service, '/api')
                 package_name = path.split('/')[1]
@@ -133,7 +129,7 @@ def add_service_urls_using_metamodel(
                 if pack_arr == []:
                     package_dict_api[package_name] = pack_arr
                 pack_arr.append(path)
-        elif service_type == ServiceType.REST:
+        elif service_type == ServiceType.REST and not blacklist_utils.isBlacklistedForRest(service):
             service_url = rest_services.get(service, None)
             if service_url is not None:
                 service_path = get_service_path_from_service_url(
@@ -147,7 +143,7 @@ def add_service_urls_using_metamodel(
                     package_dict.setdefault(package, [service_path])
             else:
                 print("Service does not belong to either /api or /rest ", service)
-        if service_type == ServiceType.MIXED:
+        if service_type == ServiceType.MIXED and not blacklist_utils.isBlacklistedForRest(service):
             service_url = rest_services.get(service, None)
             if service_url is not None:
                 service_path = get_service_path_from_service_url(

--- a/lib/establish_connection.py
+++ b/lib/establish_connection.py
@@ -76,7 +76,7 @@ def get_input_params():
         const=True,
         default=False,
         dest='deprecate_rest',
-        help='api and rest rendering, with rest being deprecated')
+        help='/api and /rest rendering - with /rest being deprecated')
     args = parser.parse_args()
     metadata_url = args.metadata_url
     rest_navigation_url = args.rest_navigation_url

--- a/lib/establish_connection.py
+++ b/lib/establish_connection.py
@@ -55,11 +55,14 @@ def get_input_params():
         help='Domain name or IP address (IPv4) of the host that serves the API. '
         'Default value is "<vcenter>"')
     parser.add_argument(
-        '-ef',
-        '--enablefiltering',
-        dest='filtering',
-        help='Filters internal and unreleased apis',
-        action='store_true')
+        '-su',
+        '--show-unreleased',
+        required=False,
+        nargs='?',
+        const=True,
+        default=False,
+        dest='show_unreleased_apis',
+        help='Includes internal and unreleased apis')
     parser.add_argument(
         '-oas',
         '--oas',
@@ -73,7 +76,6 @@ def get_input_params():
         const=True,
         default=False,
         help='api and rest rendering, with rest being deprecated')
-    parser.set_defaults(filtering=False)
     args = parser.parse_args()
     metadata_url = args.metadata_url
     rest_navigation_url = args.rest_navigation_url
@@ -103,8 +105,8 @@ def get_input_params():
     global TAG_SEPARATOR
     TAG_SEPARATOR = args.tag_separator
 
-    global enable_filtering
-    enable_filtering = args.filtering
+    global show_unreleased_apis
+    show_unreleased_apis = args.show_unreleased_apis
 
     global GENERATE_METAMODEL
     GENERATE_METAMODEL = args.metamodel_components
@@ -117,7 +119,7 @@ def get_input_params():
     global MIXED
     MIXED = args.mixed
 
-    return metadata_url, rest_navigation_url, output_dir, verify, enable_filtering, GENERATE_METAMODEL, SPECIFICATION, GENERATE_UNIQUE_OP_IDS, TAG_SEPARATOR, MIXED
+    return metadata_url, rest_navigation_url, output_dir, verify, show_unreleased_apis, GENERATE_METAMODEL, SPECIFICATION, GENERATE_UNIQUE_OP_IDS, TAG_SEPARATOR, MIXED
 
 
 def get_component_service(connector):

--- a/lib/establish_connection.py
+++ b/lib/establish_connection.py
@@ -65,6 +65,14 @@ def get_input_params():
         '--oas',
         default='3',
         help='opeanpi specification version')
+    parser.add_argument(
+        '-mixed',
+        '--mixed',
+        required=False,
+        nargs='?',
+        const=True,
+        default=False,
+        help='api and rest rendering, with rest being deprecated')
     parser.set_defaults(filtering=False)
     args = parser.parse_args()
     metadata_url = args.metadata_url
@@ -105,7 +113,11 @@ def get_input_params():
     if args.oas not in ['2', '3']:
         raise Exception(" Input Valid Specification ")
     SPECIFICATION = args.oas
-    return metadata_url, rest_navigation_url, output_dir, verify, enable_filtering, GENERATE_METAMODEL, SPECIFICATION, GENERATE_UNIQUE_OP_IDS, TAG_SEPARATOR
+
+    global MIXED
+    MIXED = args.mixed
+
+    return metadata_url, rest_navigation_url, output_dir, verify, enable_filtering, GENERATE_METAMODEL, SPECIFICATION, GENERATE_UNIQUE_OP_IDS, TAG_SEPARATOR, MIXED
 
 
 def get_component_service(connector):

--- a/lib/establish_connection.py
+++ b/lib/establish_connection.py
@@ -69,12 +69,13 @@ def get_input_params():
         default='3',
         help='opeanpi specification version')
     parser.add_argument(
-        '-mixed',
-        '--mixed',
+        '-dsr',
+        '--deprecate-slash-rest',
         required=False,
         nargs='?',
         const=True,
         default=False,
+        dest='deprecate_rest',
         help='api and rest rendering, with rest being deprecated')
     args = parser.parse_args()
     metadata_url = args.metadata_url
@@ -116,10 +117,10 @@ def get_input_params():
         raise Exception(" Input Valid Specification ")
     SPECIFICATION = args.oas
 
-    global MIXED
-    MIXED = args.mixed
+    global DEPRECATE_REST
+    DEPRECATE_REST = args.deprecate_rest
 
-    return metadata_url, rest_navigation_url, output_dir, verify, show_unreleased_apis, GENERATE_METAMODEL, SPECIFICATION, GENERATE_UNIQUE_OP_IDS, TAG_SEPARATOR, MIXED
+    return metadata_url, rest_navigation_url, output_dir, verify, show_unreleased_apis, GENERATE_METAMODEL, SPECIFICATION, GENERATE_UNIQUE_OP_IDS, TAG_SEPARATOR, DEPRECATE_REST
 
 
 def get_component_service(connector):

--- a/lib/rest_endpoint/oas3/rest_metamodel2openapi.py
+++ b/lib/rest_endpoint/oas3/rest_metamodel2openapi.py
@@ -20,7 +20,7 @@ class RestMetamodel2Openapi(RestMetamodel2Spec):
             enum_dict,
             operation_id,
             error_map,
-            enable_filtering):
+            show_unreleased_apis):
         documentation = operation_info.documentation
         params = operation_info.params
         errors = operation_info.errors
@@ -28,7 +28,7 @@ class RestMetamodel2Openapi(RestMetamodel2Spec):
         http_method = http_method.lower()
         par_array, url = self.handle_request_mapping(url, http_method, service_name,
                                                      operation_id, params, type_dict,
-                                                     structure_dict, enum_dict, enable_filtering, rest_open_ph)
+                                                     structure_dict, enum_dict, show_unreleased_apis, rest_open_ph)
         response_map = rest_open_rh.populate_response_map(
             output,
             errors,
@@ -38,7 +38,7 @@ class RestMetamodel2Openapi(RestMetamodel2Spec):
             enum_dict,
             service_name,
             operation_id,
-            enable_filtering)
+            show_unreleased_apis)
 
         path_obj = utils.build_path(
             service_name,

--- a/lib/rest_endpoint/oas3/rest_openapi_final_path_processing.py
+++ b/lib/rest_endpoint/oas3/rest_openapi_final_path_processing.py
@@ -44,10 +44,12 @@ class RestOpenapiPathProcessing(PathProcessing):
         if not os.path.exists(output_dir):
             os.mkdir(output_dir)
 
+        file_prefix = '/rest'
+
         utils.write_json_data_to_file(
             output_dir +
             os.path.sep +
-            '/rest' +
+            file_prefix +
             "_" +
             utils.remove_curly_braces(output_filename) +
             '.json',

--- a/lib/rest_endpoint/oas3/rest_openapi_final_path_processing.py
+++ b/lib/rest_endpoint/oas3/rest_openapi_final_path_processing.py
@@ -44,12 +44,10 @@ class RestOpenapiPathProcessing(PathProcessing):
         if not os.path.exists(output_dir):
             os.mkdir(output_dir)
 
-        file_prefix = '/rest'
-
         utils.write_json_data_to_file(
             output_dir +
             os.path.sep +
-            file_prefix +
+            'rest' +
             "_" +
             utils.remove_curly_braces(output_filename) +
             '.json',

--- a/lib/rest_endpoint/oas3/rest_openapi_parameter_handler.py
+++ b/lib/rest_endpoint/oas3/rest_openapi_parameter_handler.py
@@ -13,21 +13,20 @@ class RestOpenapiParaHandler():
             type_dict,
             structure_svc,
             enum_svc,
-            enable_filtering):
+            show_unreleased_apis):
         """
         Converts metamodel fieldinfo to swagger parameter.
         """
         parameter_obj = {}
         ref_path = "#/components/schemas/"
-        tpHandler = RestTypeHandler()
+        tpHandler = RestTypeHandler(show_unreleased_apis)
         tpHandler.visit_type_category(
             input_parameter_obj.type,
             parameter_obj,
             type_dict,
             structure_svc,
             enum_svc,
-            ref_path,
-            enable_filtering)
+            ref_path)
         if 'required' not in parameter_obj:
             parameter_obj['required'] = True
         parameter_obj['in'] = param_type
@@ -62,7 +61,7 @@ class RestOpenapiParaHandler():
             type_dict,
             structure_svc,
             enum_svc,
-            enable_filtering):
+            show_unreleased_apis):
         """
         Creates a  json object wrapper around request body parameters. parameter names are used as keys and the
         parameters as values.
@@ -81,7 +80,7 @@ class RestOpenapiParaHandler():
         body_obj['properties'] = properties_obj
         required = []
         ref_path = "#/components/schemas/"
-        tpHandler = RestTypeHandler()
+        tpHandler = RestTypeHandler(show_unreleased_apis)
         for param in body_param_list:
             parameter_obj = {}
             tpHandler.visit_type_category(
@@ -90,8 +89,7 @@ class RestOpenapiParaHandler():
                 type_dict,
                 structure_svc,
                 enum_svc,
-                ref_path,
-                enable_filtering)
+                ref_path)
             parameter_obj['description'] = param.documentation
             properties_obj[param.name] = parameter_obj
             if 'required' not in parameter_obj:
@@ -121,7 +119,7 @@ class RestOpenapiParaHandler():
             type_dict,
             structure_svc,
             enum_svc,
-            enable_filtering):
+            show_unreleased_apis):
         """
         Flattens query parameters specs.
         1. Create a query parameter for every field in spec.
@@ -158,15 +156,14 @@ class RestOpenapiParaHandler():
         prop_array = []
         parameter_obj = {}
         ref_path = "#/components/schemas/"
-        tpHandler = RestTypeHandler()
+        tpHandler = RestTypeHandler(show_unreleased_apis)
         tpHandler.visit_type_category(
             query_param_info.type,
             parameter_obj,
             type_dict,
             structure_svc,
             enum_svc,
-            ref_path,
-            enable_filtering)
+            ref_path)
         if '$ref' in parameter_obj:
             reference = parameter_obj['$ref'].replace(ref_path, '')
             type_ref = type_dict.get(reference, None)

--- a/lib/rest_endpoint/oas3/rest_openapi_response_handler.py
+++ b/lib/rest_endpoint/oas3/rest_openapi_response_handler.py
@@ -15,7 +15,7 @@ class RestOpenapiRespHandler():
             enum_svc,
             service_id,
             operation_id,
-            enable_filtering):
+            show_unreleased_apis):
 
         response_map = {}
         ref_path = "#/components/schemas/"
@@ -27,15 +27,14 @@ class RestOpenapiRespHandler():
             }
         }
         schema = {}
-        tpHandler = RestTypeHandler()
+        tpHandler = RestTypeHandler(show_unreleased_apis)
         tpHandler.visit_type_category(
             output.type,
             schema,
             type_dict,
             structure_svc,
             enum_svc,
-            ref_path,
-            enable_filtering)
+            ref_path)
         # if type of schema is void, don't include it.
         # this prevents showing response as void in swagger-ui
         if schema is not None:
@@ -72,8 +71,7 @@ class RestOpenapiRespHandler():
                 type_dict,
                 structure_svc,
                 enum_svc,
-                ref_path,
-                enable_filtering)
+                ref_path)
             schema_obj = {
                 'type': 'object', 'properties': {
                     'type': {

--- a/lib/rest_endpoint/rest_deprecation_handler.py
+++ b/lib/rest_endpoint/rest_deprecation_handler.py
@@ -1,0 +1,29 @@
+class RestDeprecationHandler:
+
+    def __init__(self, replacement_map):
+        '''
+        The replacement navigation map is used when MIXED specification is issued (@VERB + an old annotation standard)
+        It contains mappings to url paths, served as replacements. The structure of the map is the following:
+        service -> operation -> method -> raplacement path
+        '''
+        self.replacement_map = replacement_map
+
+    def add_deprecation_information(self, path_obj, package_name, service_name):
+        replacement_path = "<unknown>"
+        path_obj["deprecated"] = True
+
+        # construct file name
+        api_file_name = "api_" + package_name + ".json"
+
+        # Could be a more intelligent resolution - guessing based on key words?
+        operation_map = self.replacement_map.get(service_name)
+        if operation_map is not None and "operationId" in path_obj:
+            method_map = operation_map.get(path_obj["operationId"])
+            if method_map is not None and "method" in path_obj:
+                # get concrete path and format accordingly
+                replacement_path = method_map.get(path_obj["method"])
+                replacement_path = replacement_path.replace("/", "~1")
+                replacement_path = api_file_name + "#/paths/" + replacement_path + "/" + path_obj["method"]
+
+        path_obj["x-vmw-deprecated"] = {"replacement": replacement_path}
+

--- a/lib/rest_endpoint/rest_deprecation_handler.py
+++ b/lib/rest_endpoint/rest_deprecation_handler.py
@@ -2,9 +2,7 @@ class RestDeprecationHandler:
 
     def __init__(self, replacement_map):
         '''
-        The replacement navigation map is used when MIXED specification is issued (@VERB + an old annotation standard)
-        It contains mappings to url paths, served as replacements. The structure of the map is the following:
-        service -> operation -> method -> raplacement path
+        service -> operation -> method -> raplacement path ; for deprecated /rest
         '''
         self.replacement_map = replacement_map
 

--- a/lib/rest_endpoint/rest_deprecation_handler.py
+++ b/lib/rest_endpoint/rest_deprecation_handler.py
@@ -1,10 +1,10 @@
 class RestDeprecationHandler:
 
-    def __init__(self, replacement_map):
+    def __init__(self, replacement_dict):
         '''
-        service -> operation -> method -> raplacement path ; for deprecated /rest
+        service -> operation -> (method, raplacement path) ; for deprecated /rest
         '''
-        self.replacement_map = replacement_map
+        self.replacement_dict = replacement_dict
 
     def add_deprecation_information(self, path_obj, package_name, service_name):
         replacement_path = "<unknown>"
@@ -14,14 +14,14 @@ class RestDeprecationHandler:
         api_file_name = "api_" + package_name + ".json"
 
         # Could be a more intelligent resolution - guessing based on key words?
-        operation_map = self.replacement_map.get(service_name)
+        operation_map = self.replacement_dict.get(service_name)
         if operation_map is not None and "operationId" in path_obj:
-            method_map = operation_map.get(path_obj["operationId"])
-            if method_map is not None and "method" in path_obj:
+            method_path_tuple = operation_map.get(path_obj["operationId"])
+            if method_path_tuple is not None:
                 # get concrete path and format accordingly
-                replacement_path = method_map.get(path_obj["method"])
+                replacement_path = method_path_tuple[1]
                 replacement_path = replacement_path.replace("/", "~1")
-                replacement_path = api_file_name + "#/paths/" + replacement_path + "/" + path_obj["method"]
+                replacement_path = api_file_name + "#/paths/" + replacement_path + "/" + method_path_tuple[0]
 
         path_obj["x-vmw-deprecated"] = {"replacement": replacement_path}
 

--- a/lib/rest_endpoint/rest_metamodel2spec.py
+++ b/lib/rest_endpoint/rest_metamodel2spec.py
@@ -14,7 +14,7 @@ class RestMetamodel2Spec():
             enum_dict,
             operation_id,
             error_map,
-            enable_filtering):
+            show_unreleased_apis):
         pass
 
     def handle_request_mapping(
@@ -27,7 +27,7 @@ class RestMetamodel2Spec():
             type_dict,
             structure_svc,
             enum_svc,
-            enable_filtering,
+            show_unreleased_apis,
             spec):
         if method_type in ('post', 'put', 'patch'):
             return self.process_put_post_patch_request(
@@ -38,7 +38,7 @@ class RestMetamodel2Spec():
                 type_dict,
                 structure_svc,
                 enum_svc,
-                enable_filtering,
+                show_unreleased_apis,
                 spec)
         if method_type == 'get':
             return self.process_get_request(
@@ -47,7 +47,7 @@ class RestMetamodel2Spec():
                 type_dict,
                 structure_svc,
                 enum_svc,
-                enable_filtering,
+                show_unreleased_apis,
                 spec)
         if method_type == 'delete':
             return self.process_delete_request(
@@ -56,7 +56,7 @@ class RestMetamodel2Spec():
                 type_dict,
                 structure_svc,
                 enum_svc,
-                enable_filtering,
+                show_unreleased_apis,
                 spec)
 
     def process_put_post_patch_request(
@@ -68,7 +68,7 @@ class RestMetamodel2Spec():
             type_dict,
             structure_svc,
             enum_svc,
-            enable_filtering,
+            show_unreleased_apis,
             spec):
         """
         Handles http post/put/patch request.
@@ -80,7 +80,7 @@ class RestMetamodel2Spec():
         par_array = []
         for field_info in path_param_list:
             parx = spec.convert_field_info_to_swagger_parameter(
-                'path', field_info, type_dict, structure_svc, enum_svc, enable_filtering)
+                'path', field_info, type_dict, structure_svc, enum_svc, show_unreleased_apis)
             par_array.append(parx)
 
         # Body
@@ -94,7 +94,7 @@ class RestMetamodel2Spec():
                 type_dict,
                 structure_svc,
                 enum_svc,
-                enable_filtering)
+                show_unreleased_apis)
             if parx is not None:
                 par_array.append(parx)
 
@@ -107,7 +107,7 @@ class RestMetamodel2Spec():
             type_dict,
             structure_svc,
             enum_svc,
-            enable_filtering,
+            show_unreleased_apis,
             spec):
         param_array = []
         path_param_list, other_params_list, new_url = utils.extract_path_parameters(
@@ -115,7 +115,7 @@ class RestMetamodel2Spec():
 
         for field_info in path_param_list:
             parameter_obj = spec.convert_field_info_to_swagger_parameter(
-                'path', field_info, type_dict, structure_svc, enum_svc, enable_filtering)
+                'path', field_info, type_dict, structure_svc, enum_svc, show_unreleased_apis)
             param_array.append(parameter_obj)
 
         # process query parameters
@@ -124,7 +124,7 @@ class RestMetamodel2Spec():
             # handling of all the query parameters; filter as well as non
             # filter
             flattened_params = spec.flatten_query_param_spec(
-                field_info, type_dict, structure_svc, enum_svc, enable_filtering)
+                field_info, type_dict, structure_svc, enum_svc, show_unreleased_apis)
             if flattened_params is not None:
                 param_array = param_array + flattened_params
         return param_array, new_url
@@ -136,18 +136,18 @@ class RestMetamodel2Spec():
             type_dict,
             structure_svc,
             enum_svc,
-            enable_filtering,
+            show_unreleased_apis,
             spec):
         path_param_list, other_params, new_url = utils.extract_path_parameters(
             params, url)
         param_array = []
         for field_info in path_param_list:
             parx = spec.convert_field_info_to_swagger_parameter(
-                'path', field_info, type_dict, structure_svc, enum_svc, enable_filtering)
+                'path', field_info, type_dict, structure_svc, enum_svc, show_unreleased_apis)
             param_array.append(parx)
         for field_info in other_params:
             parx = spec.convert_field_info_to_swagger_parameter(
-                'query', field_info, type_dict, structure_svc, enum_svc, enable_filtering)
+                'query', field_info, type_dict, structure_svc, enum_svc, show_unreleased_apis)
             param_array.append(parx)
         return param_array, new_url
 

--- a/lib/rest_endpoint/rest_navigation_handler.py
+++ b/lib/rest_endpoint/rest_navigation_handler.py
@@ -1,0 +1,12 @@
+from lib import utils
+
+class RestNavigationHandler:
+
+    def __init__(self, rest_navigation_url):
+        self.rest_navigation_url = rest_navigation_url
+
+    def get_service_operations(self, service_url):
+        return utils.get_json(self.rest_navigation_url + service_url + '?~method=OPTIONS', False)
+
+    def get_rest_navigation_url(self):
+        return self.rest_navigation_url

--- a/lib/rest_endpoint/rest_type_handler.py
+++ b/lib/rest_endpoint/rest_type_handler.py
@@ -4,6 +4,9 @@ from lib.type_handler_common import TypeHandlerCommon
 
 class RestTypeHandler(TypeHandlerCommon):
 
+    def __init__(self, show_unreleased_apis):
+        TypeHandlerCommon.__init__(self, show_unreleased_apis)
+
     def visit_generic(
             self,
             generic_instantiation,
@@ -11,8 +14,7 @@ class RestTypeHandler(TypeHandlerCommon):
             type_dict,
             structure_svc,
             enum_svc,
-            ref_path,
-            enable_filtering):
+            ref_path):
         if generic_instantiation.generic_type == 'OPTIONAL':
             new_prop['required'] = False
             self.visit_type_category(
@@ -21,8 +23,7 @@ class RestTypeHandler(TypeHandlerCommon):
                 type_dict,
                 structure_svc,
                 enum_svc,
-                ref_path,
-                enable_filtering)
+                ref_path)
         elif generic_instantiation.generic_type == 'LIST':
             new_prop['type'] = 'array'
             self.visit_type_category(
@@ -31,8 +32,7 @@ class RestTypeHandler(TypeHandlerCommon):
                 type_dict,
                 structure_svc,
                 enum_svc,
-                ref_path,
-                enable_filtering)
+                ref_path)
         elif generic_instantiation.generic_type == 'SET':
             new_prop['type'] = 'array'
             new_prop['uniqueItems'] = True
@@ -42,8 +42,7 @@ class RestTypeHandler(TypeHandlerCommon):
                 type_dict,
                 structure_svc,
                 enum_svc,
-                ref_path,
-                enable_filtering)
+                ref_path)
         elif generic_instantiation.generic_type == 'MAP':
             # Have static key/value pair object maping for /rest paths
             # while use additionalProperties for /api paths
@@ -58,8 +57,7 @@ class RestTypeHandler(TypeHandlerCommon):
                     type_dict,
                     structure_svc,
                     enum_svc,
-                    ref_path,
-                    enable_filtering)
+                    ref_path)
             else:
                 new_type['properties']['key'] = {
                     'type': utils.metamodel_to_swagger_type_converter(
@@ -76,8 +74,7 @@ class RestTypeHandler(TypeHandlerCommon):
                     type_dict,
                     structure_svc,
                     enum_svc,
-                    ref_path,
-                    enable_filtering)
+                    ref_path)
 
             elif generic_instantiation.map_value_type.category == 'BUILTIN':
                 new_type['properties']['value'] = {
@@ -92,8 +89,7 @@ class RestTypeHandler(TypeHandlerCommon):
                     type_dict,
                     structure_svc,
                     enum_svc,
-                    ref_path,
-                    enable_filtering)
+                    ref_path)
                 new_type['properties']['value'] = temp_new_type
 
             new_prop['type'] = 'array'

--- a/lib/rest_endpoint/rest_url_processing.py
+++ b/lib/rest_endpoint/rest_url_processing.py
@@ -80,7 +80,7 @@ class RestUrlProcessing(UrlProcessing):
                             http_error_map,
                             show_unreleased_apis)
 
-                    if deprecation_handler is not None and service_end_point == "/mixed":
+                    if deprecation_handler is not None and service_end_point == "/deprecated":
                         deprecation_handler.add_deprecation_information(path, package_name, service_name)
                     path_list.append(path)
                 continue
@@ -141,7 +141,7 @@ class RestUrlProcessing(UrlProcessing):
                         http_error_map,
                         show_unreleased_apis)
 
-                if deprecation_handler is not None and service_end_point == "/mixed":
+                if deprecation_handler is not None and service_end_point == "/deprecated":
                     deprecation_handler.add_deprecation_information(path, package_name, service_name)
                 path_list.append(path)
         path_dict = self.convert_path_list_to_path_map(path_list)

--- a/lib/rest_endpoint/rest_url_processing.py
+++ b/lib/rest_endpoint/rest_url_processing.py
@@ -2,6 +2,7 @@ import os
 import six
 from lib import utils
 from lib.url_processing import UrlProcessing
+from . import rest_deprecation_handler
 from .oas3.rest_metamodel2openapi import RestMetamodel2Openapi
 from .swagger2.rest_metamodel2swagger import RestMetamodel2Swagger
 from .oas3.rest_openapi_final_path_processing import RestOpenapiPathProcessing
@@ -27,14 +28,16 @@ class RestUrlProcessing(UrlProcessing):
             service_dict,
             service_url_dict,
             http_error_map,
-            rest_navigation_url,
+            rest_navigation_handler,
             enable_filtering,
             spec,
-            gen_unique_op_id):
+            gen_unique_op_id,
+            deprecation_handler=None):
 
         print('processing package ' + package_name + os.linesep)
         type_dict = {}
         path_list = []
+
         for service_url in service_urls:
             service_name, service_end_point = service_url_dict.get(
                 service_url, None)
@@ -77,12 +80,13 @@ class RestUrlProcessing(UrlProcessing):
                             http_error_map,
                             enable_filtering)
 
+                    if deprecation_handler is not None and service_end_point == "/mixed":
+                        deprecation_handler.add_deprecation_information(path, package_name, service_name)
                     path_list.append(path)
                 continue
             # use rest navigation service to get the REST mappings for a
             # service.
-            service_operations = utils.get_json(
-                rest_navigation_url + service_url + '?~method=OPTIONS', False)
+            service_operations = rest_navigation_handler.get_service_operations(service_url)
             if service_operations is None:
                 continue
 
@@ -109,7 +113,7 @@ class RestUrlProcessing(UrlProcessing):
                     continue
                 url, method = self.find_url(service_operation['links'])
                 url = self.get_service_path_from_service_url(
-                    url, rest_navigation_url)
+                    url, rest_navigation_handler.get_rest_navigation_url())
                 operation_info = service_info.operations.get(operation_id)
 
                 if spec == '2':
@@ -137,6 +141,8 @@ class RestUrlProcessing(UrlProcessing):
                         http_error_map,
                         enable_filtering)
 
+                if deprecation_handler is not None and service_end_point == "/mixed":
+                    deprecation_handler.add_deprecation_information(path, package_name, service_name)
                 path_list.append(path)
         path_dict = self.convert_path_list_to_path_map(path_list)
         self.cleanup(path_dict=path_dict, type_dict=type_dict)

--- a/lib/rest_endpoint/rest_url_processing.py
+++ b/lib/rest_endpoint/rest_url_processing.py
@@ -29,7 +29,7 @@ class RestUrlProcessing(UrlProcessing):
             service_url_dict,
             http_error_map,
             rest_navigation_handler,
-            enable_filtering,
+            show_unreleased_apis,
             spec,
             gen_unique_op_id,
             deprecation_handler=None):
@@ -44,14 +44,14 @@ class RestUrlProcessing(UrlProcessing):
             service_info = service_dict.get(service_name, None)
             if service_info is None:
                 continue
-            if utils.is_filtered(service_info.metadata, enable_filtering):
+            if (not show_unreleased_apis) and utils.is_filtered(service_info.metadata):
                 continue
             if self.contains_rm_annotation(service_info):
                 for operation in service_info.operations.values():
                     url, method = self.find_url_method(operation)
                     operation_id = operation.name
                     op_metadata = service_info.operations[operation_id].metadata
-                    if utils.is_filtered(op_metadata, enable_filtering):
+                    if (not show_unreleased_apis) and utils.is_filtered(op_metadata):
                         continue
                     operation_info = service_info.operations.get(operation_id)
 
@@ -66,7 +66,7 @@ class RestUrlProcessing(UrlProcessing):
                             enum_dict,
                             operation_id,
                             http_error_map,
-                            enable_filtering)
+                            show_unreleased_apis)
                     if spec == '3':
                         path = openapi.get_path(
                             operation_info,
@@ -78,7 +78,7 @@ class RestUrlProcessing(UrlProcessing):
                             enum_dict,
                             operation_id,
                             http_error_map,
-                            enable_filtering)
+                            show_unreleased_apis)
 
                     if deprecation_handler is not None and service_end_point == "/mixed":
                         deprecation_handler.add_deprecation_information(path, package_name, service_name)
@@ -109,7 +109,7 @@ class RestUrlProcessing(UrlProcessing):
                 if operation_id not in service_info.operations:
                     continue
                 op_metadata = service_info.operations[operation_id].metadata
-                if utils.is_filtered(op_metadata, enable_filtering):
+                if (not show_unreleased_apis) and utils.is_filtered(op_metadata):
                     continue
                 url, method = self.find_url(service_operation['links'])
                 url = self.get_service_path_from_service_url(
@@ -127,7 +127,7 @@ class RestUrlProcessing(UrlProcessing):
                         enum_dict,
                         operation_id,
                         http_error_map,
-                        enable_filtering)
+                        show_unreleased_apis)
                 if spec == '3':
                     path = openapi.get_path(
                         operation_info,
@@ -139,7 +139,7 @@ class RestUrlProcessing(UrlProcessing):
                         enum_dict,
                         operation_id,
                         http_error_map,
-                        enable_filtering)
+                        show_unreleased_apis)
 
                 if deprecation_handler is not None and service_end_point == "/mixed":
                     deprecation_handler.add_deprecation_information(path, package_name, service_name)

--- a/lib/rest_endpoint/swagger2/rest_metamodel2swagger.py
+++ b/lib/rest_endpoint/swagger2/rest_metamodel2swagger.py
@@ -20,7 +20,7 @@ class RestMetamodel2Swagger(RestMetamodel2Spec):
             enum_dict,
             operation_id,
             error_map,
-            enable_filtering):
+            show_unreleased_apis):
         documentation = operation_info.documentation
         params = operation_info.params
         errors = operation_info.errors
@@ -28,7 +28,7 @@ class RestMetamodel2Swagger(RestMetamodel2Spec):
         http_method = http_method.lower()
         par_array, url = self.handle_request_mapping(url, http_method, service_name,
                                                      operation_id, params, type_dict,
-                                                     structure_dict, enum_dict, enable_filtering, rest_swagg_ph)
+                                                     structure_dict, enum_dict, show_unreleased_apis, rest_swagg_ph)
         response_map = rest_swagg_rh.populate_response_map(
             output,
             errors,
@@ -38,7 +38,7 @@ class RestMetamodel2Swagger(RestMetamodel2Spec):
             enum_dict,
             service_name,
             operation_id,
-            enable_filtering)
+            show_unreleased_apis)
 
         path_obj = utils.build_path(
             service_name,

--- a/lib/rest_endpoint/swagger2/rest_metamodel2swagger.py
+++ b/lib/rest_endpoint/swagger2/rest_metamodel2swagger.py
@@ -26,8 +26,6 @@ class RestMetamodel2Swagger(RestMetamodel2Spec):
         errors = operation_info.errors
         output = operation_info.output
         http_method = http_method.lower()
-        consumes_json = self.find_consumes(http_method)
-        produces = None
         par_array, url = self.handle_request_mapping(url, http_method, service_name,
                                                      operation_id, params, type_dict,
                                                      structure_dict, enum_dict, enable_filtering, rest_swagg_ph)
@@ -49,20 +47,10 @@ class RestMetamodel2Swagger(RestMetamodel2Spec):
             documentation,
             par_array,
             operation_id=operation_id,
-            responses=response_map,
-            consumes=consumes_json,
-            produces=produces)
+            responses=response_map)
         self.post_process_path(path_obj)
         path = utils.add_basic_auth(path_obj)
         return path
-
-    def find_consumes(self, method_type):
-        """
-        Determine mediaType for input parameters in request body.
-        """
-        if method_type in ('get', 'delete'):
-            return None
-        return ['application/json']
 
     def post_process_path(self, path_obj):
         # Temporary fixes necessary for generated spec files.

--- a/lib/rest_endpoint/swagger2/rest_swagger_final_path_processing.py
+++ b/lib/rest_endpoint/swagger2/rest_swagger_final_path_processing.py
@@ -35,6 +35,12 @@ class RestSwaggerPathProcessing(PathProcessing):
                 'basic_auth': {
                     'type': 'basic'}},
             'basePath': '/rest',
+            'produces': [
+                'application/json'
+            ],
+            "consumes": [
+                "application/json"
+            ],
             'tags': [],
             'schemes': [
                 'https',

--- a/lib/rest_endpoint/swagger2/rest_swagger_final_path_processing.py
+++ b/lib/rest_endpoint/swagger2/rest_swagger_final_path_processing.py
@@ -55,12 +55,10 @@ class RestSwaggerPathProcessing(PathProcessing):
         if not os.path.exists(output_dir):
             os.mkdir(output_dir)
 
-        file_prefix = '/rest'
-
         utils.write_json_data_to_file(
             output_dir +
             os.path.sep +
-            file_prefix +
+            'rest' +
             "_" +
             utils.remove_curly_braces(output_filename) +
             '.json',

--- a/lib/rest_endpoint/swagger2/rest_swagger_final_path_processing.py
+++ b/lib/rest_endpoint/swagger2/rest_swagger_final_path_processing.py
@@ -49,10 +49,12 @@ class RestSwaggerPathProcessing(PathProcessing):
         if not os.path.exists(output_dir):
             os.mkdir(output_dir)
 
+        file_prefix = '/rest'
+
         utils.write_json_data_to_file(
             output_dir +
             os.path.sep +
-            '/rest' +
+            file_prefix +
             "_" +
             utils.remove_curly_braces(output_filename) +
             '.json',

--- a/lib/rest_endpoint/swagger2/rest_swagger_parameter_handler.py
+++ b/lib/rest_endpoint/swagger2/rest_swagger_parameter_handler.py
@@ -13,21 +13,20 @@ class RestSwaggerParaHandler():
             type_dict,
             structure_svc,
             enum_svc,
-            enable_filtering):
+            show_unreleased_apis):
         """
         Converts metamodel fieldinfo to swagger parameter.
         """
         parameter_obj = {}
         ref_path = "#/definitions/"
-        tpHandler = RestTypeHandler()
+        tpHandler = RestTypeHandler(show_unreleased_apis)
         tpHandler.visit_type_category(
             input_parameter_obj.type,
             parameter_obj,
             type_dict,
             structure_svc,
             enum_svc,
-            ref_path,
-            enable_filtering)
+            ref_path)
         if 'required' not in parameter_obj:
             parameter_obj['required'] = True
         parameter_obj['in'] = param_type
@@ -56,7 +55,7 @@ class RestSwaggerParaHandler():
             type_dict,
             structure_svc,
             enum_svc,
-            enable_filtering):
+            show_unreleased_apis):
         """
         Creates a  json object wrapper around request body parameters. parameter names are used as keys and the
         parameters as values.
@@ -75,7 +74,7 @@ class RestSwaggerParaHandler():
         body_obj['properties'] = properties_obj
         required = []
         ref_path = "#/definitions/"
-        tpHandler = RestTypeHandler()
+        tpHandler = RestTypeHandler(show_unreleased_apis)
         for param in body_param_list:
             parameter_obj = {}
             tpHandler.visit_type_category(
@@ -84,8 +83,7 @@ class RestSwaggerParaHandler():
                 type_dict,
                 structure_svc,
                 enum_svc,
-                ref_path,
-                enable_filtering)
+                ref_path)
             parameter_obj['description'] = param.documentation
             properties_obj[param.name] = parameter_obj
             if 'required' not in parameter_obj:
@@ -113,7 +111,7 @@ class RestSwaggerParaHandler():
             type_dict,
             structure_svc,
             enum_svc,
-            enable_filtering):
+            show_unreleased_apis):
         """
         Flattens query parameters specs.
         1. Create a query parameter for every field in spec.
@@ -150,15 +148,14 @@ class RestSwaggerParaHandler():
         prop_array = []
         parameter_obj = {}
         ref_path = "#/definitions/"
-        tpHandler = RestTypeHandler()
+        tpHandler = RestTypeHandler(show_unreleased_apis)
         tpHandler.visit_type_category(
             query_param_info.type,
             parameter_obj,
             type_dict,
             structure_svc,
             enum_svc,
-            ref_path,
-            enable_filtering)
+            ref_path)
         if '$ref' in parameter_obj:
             reference = parameter_obj['$ref'].replace(ref_path, '')
             type_ref = type_dict.get(reference, None)

--- a/lib/rest_endpoint/swagger2/rest_swagger_response_handler.py
+++ b/lib/rest_endpoint/swagger2/rest_swagger_response_handler.py
@@ -15,21 +15,20 @@ class RestSwaggerRespHandler():
             enum_svc,
             service_id,
             operation_id,
-            enable_filtering):
+            show_unreleased_apis):
 
         response_map = {}
         ref_path = "#/definitions/"
         success_response = {'description': output.documentation}
         schema = {}
-        tpHandler = RestTypeHandler()
+        tpHandler = RestTypeHandler(show_unreleased_apis)
         tpHandler.visit_type_category(
             output.type,
             schema,
             type_dict,
             structure_svc,
             enum_svc,
-            ref_path,
-            enable_filtering)
+            ref_path)
         # if type of schema is void, don't include it.
         # this prevents showing response as void in swagger-ui
         if schema is not None:
@@ -66,8 +65,7 @@ class RestSwaggerRespHandler():
                 type_dict,
                 structure_svc,
                 enum_svc,
-                ref_path,
-                enable_filtering)
+                ref_path)
             schema_obj = {
                 'type': 'object', 'properties': {
                     'type': {

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -59,6 +59,16 @@ def is_filtered(metadata, enable_filtering):
     return False
 
 
+def combine_dicts_with_list_values(extended, added):
+    for k, v in added.items():
+        list_to_extend = extended.get(k, None)
+        if list_to_extend is None:
+            extended[k] = v
+        else:
+            list_to_extend.extend(v)
+            extended[k] = list(set(list_to_extend))
+
+
 def extract_path_parameters(params, url):
     """
     Return list of field_infos which are path variables, another list of

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -47,9 +47,7 @@ def load_description():
     return desc
 
 
-def is_filtered(metadata, enable_filtering):
-    if not enable_filtering:
-        return False
+def is_filtered(metadata):
     if len(metadata) == 0:
         return False
     if 'TechPreview' in metadata:

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -146,10 +146,14 @@ def build_path(
         path_obj['parameters'] = parameters
     if responses is not None:
         path_obj['responses'] = responses
+
+    # TODO - currently 'consumes' and 'produces are global and hardcoded;
+    # Create a finer-grained approach, utilizing the checks below
     if consumes is not None:
         path_obj['consumes'] = consumes
     if produces is not None:
         path_obj['produces'] = produces
+
     if operation_id is not None:
         path_obj['operationId'] = operation_id
     return path_obj

--- a/test_api_endpoint.py
+++ b/test_api_endpoint.py
@@ -8,7 +8,8 @@ from lib.api_endpoint.oas3.api_openapi_parameter_handler import ApiOpenapiParaHa
 
 class TestApiTypeHandler(unittest.TestCase):
 
-    api_tphandler = ApiTypeHandler()
+    # Showing unreleased apis (disabled filtering)
+    api_tphandler = ApiTypeHandler(True)
 
     def test_visit_generic(self):
         # case 1: when generic instantiation type is 'SET' and category is 'BUILT-IN'
@@ -43,14 +44,14 @@ class TestApiTypeHandler(unittest.TestCase):
         }
         '''
         new_prop = {}
-        self.api_tphandler.visit_generic(generic_instantiation_mock, new_prop, {}, structure_dict, {}, '#/definitions/', False )
+        self.api_tphandler.visit_generic(generic_instantiation_mock, new_prop, {}, structure_dict, {}, '#/definitions/')
         new_prop_expected = {'type': 'array', 'uniqueItems': True, 'items': {'type': 'date-time'}}
         self.assertEqual(new_prop_expected, new_prop)
 
         # case 2: when generic instantiation type is 'OPTIONAL' and category is 'BUILT-IN'
         generic_instantiation_mock.generic_type = 'OPTIONAL'
         new_prop = {}
-        self.api_tphandler.visit_generic(generic_instantiation_mock, new_prop, {}, structure_dict, {}, '#/definitions/', False )
+        self.api_tphandler.visit_generic(generic_instantiation_mock, new_prop, {}, structure_dict, {}, '#/definitions/')
         new_prop_expected = {'required': False, 'type': 'date-time'}
         self.assertEqual(new_prop_expected, new_prop)
 
@@ -74,7 +75,7 @@ class TestApiTypeHandler(unittest.TestCase):
         }
         '''
         new_prop = {}
-        self.api_tphandler.visit_generic(generic_instantiation_mock, new_prop, {}, structure_dict, {}, '#/definitions/', False )
+        self.api_tphandler.visit_generic(generic_instantiation_mock, new_prop, {}, structure_dict, {}, '#/definitions/')
         new_prop_expected = {'type': 'array', 'items': {'$ref': '#/definitions/com.vmware.package.mock'}}
         self.assertEqual(new_prop_expected, new_prop)
 
@@ -103,7 +104,7 @@ class TestApiTypeHandler(unittest.TestCase):
         }
         '''
         new_prop = {}
-        self.api_tphandler.visit_generic(generic_instantiation_mock, new_prop, {}, structure_dict, {}, '#/definitions/', False )
+        self.api_tphandler.visit_generic(generic_instantiation_mock, new_prop, {}, structure_dict, {}, '#/definitions/')
         new_prop_expected = {'type': 'object', 'additionalProperties': {'type': 'integer'}}
         self.assertEqual(new_prop_expected, new_prop)
 
@@ -114,7 +115,7 @@ class TestApiTypeHandler(unittest.TestCase):
         'com.vmware.package.mock': {}
         }
         new_prop = {}
-        self.api_tphandler.visit_generic(generic_instantiation_mock, new_prop, type_dict, structure_dict, {}, '#/definitions/', False )
+        self.api_tphandler.visit_generic(generic_instantiation_mock, new_prop, type_dict, structure_dict, {}, '#/definitions/')
         new_prop_expected = {'type': 'object', 'additionalProperties': {'$ref': '#/definitions/com.vmware.package.mock'}}
         self.assertEqual(new_prop_expected, new_prop)
 
@@ -125,7 +126,7 @@ class TestApiTypeHandler(unittest.TestCase):
         map_value_type_mock.category = 'GENERIC'
         map_value_type_mock.generic_instantiation = generic_instantiation_map_value_type_mock
         new_prop = {}
-        self.api_tphandler.visit_generic(generic_instantiation_mock, new_prop, type_dict, structure_dict, {}, '#/definitions/', False )
+        self.api_tphandler.visit_generic(generic_instantiation_mock, new_prop, type_dict, structure_dict, {}, '#/definitions/')
         new_prop_expected = {'type': 'object', 'additionalProperties': {'$ref': '#/definitions/com.vmware.package.mock'}}
         self.assertEqual(new_prop_expected, new_prop)
 

--- a/test_api_endpoint.py
+++ b/test_api_endpoint.py
@@ -146,6 +146,16 @@ class TestApiUrlProcessing(unittest.TestCase):
         self.assertEqual(method_expected, method_actual)
         self.assertEqual(url_path_expected, url_path_actual)
 
+        # http operation inside metadata does not belong to put, post, patch, get or delete
+        metadata = {'RequestMapping': element_info_mock}
+        method_expected = None
+        url_path_expected = None
+        api_url_process = ApiUrlProcessing()
+        method_actual, url_path_actual = api_url_process.api_get_url_and_method(metadata)
+        self.assertEqual(method_expected, method_actual)
+        self.assertEqual(url_path_expected, url_path_actual)
+
+
 class TestApiMetamodel2Spec(unittest.TestCase):
 
     element_value_mock = mock.Mock()

--- a/test_api_oas.py
+++ b/test_api_oas.py
@@ -388,7 +388,43 @@ class TestApiOpenapiPathProcessing(unittest.TestCase):
         self.api_openapi_path.remove_query_params(path_dict)
         self.assertEqual(path_dict, path_dict_expected)
 
-        # case 2.2: both of them have query parameter
+        # case 2.2: only one of them as query parameter without specified enum value
+        path_dict = {
+            'mock/path1?action': {
+                'post': {
+                    'parameters': []
+                }
+            },
+            'mock/path1': {
+                'get': {
+                    'parameters': []
+                }
+            }
+        }
+        path_dict_expected = {
+            'mock/path1': {
+                'post': {
+                    'parameters': [
+                        {
+                            'name': 'action',
+                            'in': 'query',
+                            'description': 'action',
+                            'required': True,
+                            'schema': {
+                                'type': 'string'
+                            }
+                        }
+                    ]
+                },
+                'get': {
+                    'parameters': []
+                }
+            }
+        }
+        self.api_openapi_path.remove_query_params(path_dict)
+        self.assertEqual(path_dict, path_dict_expected)
+
+        # case 2.3: both of them have query parameter
         path_dict = {
             'mock/path1?action=mock_action_1':{
                 'post':{

--- a/test_api_swagger.py
+++ b/test_api_swagger.py
@@ -341,8 +341,42 @@ class TestApiSwaggerFinalPath(unittest.TestCase):
         }
         self.api_swagger_path.remove_query_params(path_dict)
         self.assertEqual(path_dict, path_dict_expected)
+
+        # case 2.2: only one of them as query parameter without specified enum value
+        path_dict = {
+            'mock/path1?action':{
+                'post':{
+                    'parameters' : []
+                }
+            },
+            'mock/path1':{
+                'get':{
+                    'parameters' : []
+                }
+            }
+        }
+        path_dict_expected = {
+            'mock/path1': {
+                'post': {
+                    'parameters': [
+                        {
+                            'name': 'action',
+                            'in': 'query',
+                            'description':'action',
+                            'required': True,
+                            'type': 'string'
+                        }
+                    ]
+                },
+                'get': {
+                    'parameters' : []
+                }
+            }
+        }
+        self.api_swagger_path.remove_query_params(path_dict)
+        self.assertEqual(path_dict, path_dict_expected)
     
-        # case 2.2: both of them have query parameter
+        # case 2.3: both of them have query parameter
         path_dict = {
             'mock/path1?action=mock_action_1':{
                 'post':{

--- a/test_api_swagger.py
+++ b/test_api_swagger.py
@@ -435,19 +435,6 @@ class TestApiMetamodel2Swagger(unittest.TestCase):
 
     api_meta2swagger = ApiMetamodel2Swagger()
 
-    def test_find_consumes(self):
-        # case 1: operation is get or delete
-        mock_method_type = 'get'
-        media_type_actual = self.api_meta2swagger.find_consumes(mock_method_type)
-        media_type_expected = None
-        self.assertEqual(media_type_expected, media_type_actual)
-
-        # case 2: operation is other than get or delete
-        mock_method_type = 'mock_operation'
-        media_type_actual = self.api_meta2swagger.find_consumes(mock_method_type)
-        media_type_expected = ['application/json']
-        self.assertEqual(media_type_expected, media_type_actual)
-
     def test_post_process_path(self):
         # case 1: adding header parameter in list of parameters 
         # if path equals '/com/vmware/cis/session' and method is 'post

--- a/test_lib.py
+++ b/test_lib.py
@@ -149,7 +149,7 @@ class TestDictionaryProcessing(unittest.TestCase):
         '''
         path_list_expected = []
         service_type_actual, path_list_actual = dict_processing.get_paths_inside_metamodel(service, service_dict)
-        self.assertEqual(ServiceType.REST, service_type_actual)
+        self.assertEqual(ServiceType.SLASH_REST, service_type_actual)
         self.assertEqual(path_list_expected, path_list_actual)
 
         #case 2: https methods ('put', 'post', 'patch', 'get', 'delete') in metadata.keys
@@ -185,7 +185,7 @@ class TestDictionaryProcessing(unittest.TestCase):
         '''
         path_list_expected = ['mock_string_value']
         service_type_actual, path_list_actual = dict_processing.get_paths_inside_metamodel(service, service_dict)
-        self.assertEqual(ServiceType.API, service_type_actual)
+        self.assertEqual(ServiceType.SLASH_API, service_type_actual)
         self.assertEqual(path_list_expected, path_list_actual)
 
         # case 3: https methods ('put', 'post', 'patch', 'get', 'delete') in metadata.keys with deprecated applied
@@ -221,7 +221,7 @@ class TestDictionaryProcessing(unittest.TestCase):
         '''
         path_list_expected = ['mock_string_value']
         service_type_actual, path_list_actual = dict_processing.get_paths_inside_metamodel(service, service_dict, True)
-        self.assertEqual(ServiceType.API, service_type_actual)
+        self.assertEqual(ServiceType.SLASH_API, service_type_actual)
         self.assertEqual(path_list_expected, path_list_actual)
 
         # case 3.1: https methods ('put', 'post', 'patch', 'get', 'delete') in metadata.keys with deprecated applied
@@ -259,12 +259,12 @@ class TestDictionaryProcessing(unittest.TestCase):
             }
         '''
         path_list_expected = ['mock_string_value']
-        replacement_map_expected = {service: {"mock-key-1": {"put": "mock_string_value"}}}
-        replacement_map_actual = {}
-        service_type_actual, path_list_actual = dict_processing.get_paths_inside_metamodel(service, service_dict, True, replacement_map_actual)
-        self.assertEqual(ServiceType.DEPRECATED, service_type_actual)
+        replacement_dict_expected = {service: {"mock-key-1": ("put", "mock_string_value")}}
+        replacement_dict_actual = {}
+        service_type_actual, path_list_actual = dict_processing.get_paths_inside_metamodel(service, service_dict, True, replacement_dict_actual)
+        self.assertEqual(ServiceType.SLASH_REST_AND_API, service_type_actual)
         self.assertEqual(path_list_expected, path_list_actual)
-        self.assertEqual(replacement_map_expected, replacement_map_actual)
+        self.assertEqual(replacement_dict_expected, replacement_dict_actual)
 
         # case 3.2: https methods ('put', 'post', 'patch', 'get', 'delete') in metadata.keys with deprecated applied
         # and apparent in navigation service
@@ -301,17 +301,17 @@ class TestDictionaryProcessing(unittest.TestCase):
             }
         '''
         path_list_expected = ['mock_string_value']
-        replacement_map_expected = {service: {"mock-key-1": {"put": "mock_string_value"}}}
-        replacement_map_actual = {}
+        replacement_dict_expected = {service: {"mock-key-1": ("put", "mock_string_value")}}
+        replacement_dict_actual = {}
         service_type_actual, path_list_actual = dict_processing.get_paths_inside_metamodel(service,
                                                                                            service_dict,
                                                                                            True,
-                                                                                           replacement_map_actual,
+                                                                                           replacement_dict_actual,
                                                                                            "sample_service_url",
                                                                                            rest_navigation_handler)
-        self.assertEqual(ServiceType.DEPRECATED, service_type_actual)
+        self.assertEqual(ServiceType.SLASH_REST_AND_API, service_type_actual)
         self.assertEqual(path_list_expected, path_list_actual)
-        self.assertEqual(replacement_map_expected, replacement_map_actual)
+        self.assertEqual(replacement_dict_expected, replacement_dict_actual)
 
 
     def test_add_service_urls_using_metamodel(self):

--- a/test_lib.py
+++ b/test_lib.py
@@ -83,19 +83,19 @@ class TestInputs(unittest.TestCase):
             _, _, _, _, _, _, swagger_specification_actual, _, _, _, = connection.get_input_params()
         self.assertEqual(swagger_specification_expected, swagger_specification_actual)
 
-        # case 6.1: mixed option is TRUE
-        test_args = ['vmsgen', '-vc', 'v_url', '-k', '-mixed']
-        mixed_expected = True
+        # case 6.1: deprecated option is TRUE
+        test_args = ['vmsgen', '-vc', 'v_url', '-k', '-dsr']
+        deprecated_expected = True
         with mock.patch('sys.argv', test_args):
-            _, _, _, _, _, _, _, _, _, mixed_actual = connection.get_input_params()
-        self.assertEqual(mixed_expected, mixed_actual)
+            _, _, _, _, _, _, _, _, _, deprecated_actual = connection.get_input_params()
+        self.assertEqual(deprecated_expected, deprecated_actual)
 
-        # case 6.1: mixed option is FALSE
+        # case 6.1: deprecated option is FALSE
         test_args = ['vmsgen', '-vc', 'v_url', '-k']
-        mixed_expected = False
+        deprecated_expected = False
         with mock.patch('sys.argv', test_args):
-            _, _, _, _, _, _, _, _, _, mixed_actual = connection.get_input_params()
-        self.assertEqual(mixed_expected, mixed_actual)
+            _, _, _, _, _, _, _, _, _, deprecated_actual = connection.get_input_params()
+        self.assertEqual(deprecated_expected, deprecated_actual)
 
 
 class TestDictionaryProcessing(unittest.TestCase):
@@ -188,7 +188,7 @@ class TestDictionaryProcessing(unittest.TestCase):
         self.assertEqual(ServiceType.API, service_type_actual)
         self.assertEqual(path_list_expected, path_list_actual)
 
-        # case 3: https methods ('put', 'post', 'patch', 'get', 'delete') in metadata.keys with mixed applied
+        # case 3: https methods ('put', 'post', 'patch', 'get', 'delete') in metadata.keys with deprecated applied
         element_value_mock = mock.Mock()
         element_value_mock.string_value = 'mock_string_value'
         element_info_mock = mock.Mock()
@@ -224,7 +224,7 @@ class TestDictionaryProcessing(unittest.TestCase):
         self.assertEqual(ServiceType.API, service_type_actual)
         self.assertEqual(path_list_expected, path_list_actual)
 
-        # case 3.1: https methods ('put', 'post', 'patch', 'get', 'delete') in metadata.keys with mixed applied
+        # case 3.1: https methods ('put', 'post', 'patch', 'get', 'delete') in metadata.keys with deprecated applied
         # and RequestMapping apparent in the metadata
         element_value_mock = mock.Mock()
         element_value_mock.string_value = 'mock_string_value'
@@ -262,11 +262,11 @@ class TestDictionaryProcessing(unittest.TestCase):
         replacement_map_expected = {service: {"mock-key-1": {"put": "mock_string_value"}}}
         replacement_map_actual = {}
         service_type_actual, path_list_actual = dict_processing.get_paths_inside_metamodel(service, service_dict, True, replacement_map_actual)
-        self.assertEqual(ServiceType.MIXED, service_type_actual)
+        self.assertEqual(ServiceType.DEPRECATED, service_type_actual)
         self.assertEqual(path_list_expected, path_list_actual)
         self.assertEqual(replacement_map_expected, replacement_map_actual)
 
-        # case 3.2: https methods ('put', 'post', 'patch', 'get', 'delete') in metadata.keys with mixed applied
+        # case 3.2: https methods ('put', 'post', 'patch', 'get', 'delete') in metadata.keys with deprecated applied
         # and apparent in navigation service
         rest_navigation_handler = RestNavigationHandler("")
         rest_navigation_handler.get_service_operations = mock.MagicMock(return_value={})
@@ -309,7 +309,7 @@ class TestDictionaryProcessing(unittest.TestCase):
                                                                                            replacement_map_actual,
                                                                                            "sample_service_url",
                                                                                            rest_navigation_handler)
-        self.assertEqual(ServiceType.MIXED, service_type_actual)
+        self.assertEqual(ServiceType.DEPRECATED, service_type_actual)
         self.assertEqual(path_list_expected, path_list_actual)
         self.assertEqual(replacement_map_expected, replacement_map_actual)
 
@@ -365,7 +365,7 @@ class TestDictionaryProcessing(unittest.TestCase):
         self.assertEqual(package_dict_deprecated_expected, package_dict_deprecated_actual)
         self.assertEqual(package_dict_api_expected, package_dict_api_actual)
 
-        #case 4: checking for deprecated
+        #case 4: checking for package_dict_deprecated{} and package_dict_api{}
         service_dict = {
             'com.vmware.vcenter.compute.policies.VM': service_info_mock
         }

--- a/test_lib.py
+++ b/test_lib.py
@@ -365,6 +365,17 @@ class TestDictionaryProcessing(unittest.TestCase):
         self.assertEqual(package_dict_deprecated_expected, package_dict_deprecated_actual)
         self.assertEqual(package_dict_api_expected, package_dict_api_actual)
 
+        #case 4: checking for deprecated
+        service_dict = {
+            'com.vmware.vcenter.compute.policies.VM': service_info_mock
+        }
+        package_dict_deprecated_expected = {}
+        package_dict_api_expected = {'package': ['/package/mock']}
+        package_dict_api_actual, package_dict_actual, package_dict_deprecated_actual, _, = dict_processing.add_service_urls_using_metamodel(service_urls_map,service_dict,rest_navigation_handler, True)
+
+        self.assertEqual(package_dict_deprecated_expected, package_dict_deprecated_actual)
+        self.assertEqual(package_dict_api_expected, package_dict_api_actual)
+
 
 
     def test_objectTodict(self):

--- a/test_rest_deprecation.py
+++ b/test_rest_deprecation.py
@@ -1,0 +1,26 @@
+import unittest
+from unittest import mock
+
+from lib.rest_endpoint.rest_deprecation_handler import RestDeprecationHandler
+
+
+class TestRestDeprecationHandler(unittest.TestCase):
+
+    sample_package = "vsphere"
+    sample_service = "com.test.service"
+    sample_operation = "list"
+    sample_method = "get"
+    sample_path = "/com/test/sample/list"
+    replacement_map = {sample_service: {sample_operation: {sample_method: sample_path}}}
+    rest_deprecation_handler = RestDeprecationHandler(replacement_map)
+
+    def test_rest_deprecation(self):
+        path_obj = {"operationId": self.sample_operation, "method": self.sample_method}
+        self.rest_deprecation_handler.add_deprecation_information(path_obj, self.sample_package, self.sample_service)
+
+        self.assertEqual(path_obj['deprecated'], True)
+        self.assertEqual(path_obj["x-vmw-deprecated"]["replacement"], "api_vsphere.json#/paths/~1com~1test~1sample~1list/get")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test_rest_deprecation.py
+++ b/test_rest_deprecation.py
@@ -6,11 +6,11 @@ from lib.rest_endpoint.rest_deprecation_handler import RestDeprecationHandler
 
 class TestRestDeprecationHandler(unittest.TestCase):
 
-    sample_package = "vsphere"
-    sample_service = "com.test.service"
+    sample_package = "vcenter"
+    sample_service = "com.vmware.vcenter"
     sample_operation = "list"
     sample_method = "get"
-    sample_path = "/com/test/sample/list"
+    sample_path = "/rest/vcenter/vm"
     replacement_dict = {sample_service: {sample_operation: (sample_method, sample_path)}}
     rest_deprecation_handler = RestDeprecationHandler(replacement_dict)
 
@@ -19,7 +19,7 @@ class TestRestDeprecationHandler(unittest.TestCase):
         self.rest_deprecation_handler.add_deprecation_information(path_obj, self.sample_package, self.sample_service)
 
         self.assertEqual(path_obj['deprecated'], True)
-        self.assertEqual(path_obj["x-vmw-deprecated"]["replacement"], "api_vsphere.json#/paths/~1com~1test~1sample~1list/get")
+        self.assertEqual(path_obj["x-vmw-deprecated"]["replacement"], "api_vcenter.json#/paths/~1rest~1vcenter~1vm/get")
 
 
 if __name__ == '__main__':

--- a/test_rest_deprecation.py
+++ b/test_rest_deprecation.py
@@ -11,8 +11,8 @@ class TestRestDeprecationHandler(unittest.TestCase):
     sample_operation = "list"
     sample_method = "get"
     sample_path = "/com/test/sample/list"
-    replacement_map = {sample_service: {sample_operation: {sample_method: sample_path}}}
-    rest_deprecation_handler = RestDeprecationHandler(replacement_map)
+    replacement_dict = {sample_service: {sample_operation: (sample_method, sample_path)}}
+    rest_deprecation_handler = RestDeprecationHandler(replacement_dict)
 
     def test_rest_deprecation(self):
         path_obj = {"operationId": self.sample_operation, "method": self.sample_method}

--- a/test_rest_endpoint.py
+++ b/test_rest_endpoint.py
@@ -7,8 +7,8 @@ from lib.rest_endpoint.swagger2.rest_swagger_parameter_handler import RestSwagge
 from lib.rest_endpoint.oas3.rest_openapi_parameter_handler import RestOpenapiParaHandler
 
 class TestRestTypeHandler(unittest.TestCase):
-
-    rest_tphandler = RestTypeHandler()
+    # Showing unreleased apis (disabled filtering)
+    rest_tphandler = RestTypeHandler(True)
 
     def test_visit_generic(self):
         # case 1: when generic instantiation type is 'SET' and category is 'BUILT-IN'
@@ -45,7 +45,7 @@ class TestRestTypeHandler(unittest.TestCase):
         enum_dict = {}
         type_dict = {}
         new_prop = {}
-        self.rest_tphandler.visit_generic(generic_instantiation_mock, new_prop, type_dict, structure_dict, enum_dict, '#/definitions/', False )
+        self.rest_tphandler.visit_generic(generic_instantiation_mock, new_prop, type_dict, structure_dict, enum_dict, '#/definitions/')
         new_prop_expected = {'type': 'array', 'uniqueItems': True, 'items': {'type': 'date-time'}}
         self.assertEqual(new_prop_expected, new_prop)
 
@@ -54,7 +54,7 @@ class TestRestTypeHandler(unittest.TestCase):
         enum_dict = {}
         type_dict = {}
         new_prop = {}
-        self.rest_tphandler.visit_generic(generic_instantiation_mock, new_prop, type_dict, structure_dict, enum_dict, '#/definitions/', False )
+        self.rest_tphandler.visit_generic(generic_instantiation_mock, new_prop, type_dict, structure_dict, enum_dict, '#/definitions/')
         new_prop_expected = {'required': False, 'type': 'date-time'}
         self.assertEqual(new_prop_expected, new_prop)
 
@@ -80,7 +80,7 @@ class TestRestTypeHandler(unittest.TestCase):
         enum_dict = {}
         type_dict = {}
         new_prop = {}
-        self.rest_tphandler.visit_generic(generic_instantiation_mock, new_prop, type_dict, structure_dict, enum_dict, '#/definitions/', False )
+        self.rest_tphandler.visit_generic(generic_instantiation_mock, new_prop, type_dict, structure_dict, enum_dict, '#/definitions/')
         new_prop_expected = {'type': 'array', 'items': {'$ref': '#/definitions/com.vmware.package.mock'}}
         self.assertEqual(new_prop_expected, new_prop)
 
@@ -111,7 +111,7 @@ class TestRestTypeHandler(unittest.TestCase):
         enum_dict = {}
         type_dict = {}
         new_prop = {}
-        self.rest_tphandler.visit_generic(generic_instantiation_mock, new_prop, type_dict, structure_dict, enum_dict, '#/definitions/', False )
+        self.rest_tphandler.visit_generic(generic_instantiation_mock, new_prop, type_dict, structure_dict, enum_dict, '#/definitions/')
         new_prop_expected = {
             'type': 'array', 
             'items': {
@@ -133,7 +133,7 @@ class TestRestTypeHandler(unittest.TestCase):
             'com.vmware.package.mock': {}
         }
         new_prop = {}
-        self.rest_tphandler.visit_generic(generic_instantiation_mock, new_prop, type_dict, structure_dict, enum_dict, '#/definitions/', False )
+        self.rest_tphandler.visit_generic(generic_instantiation_mock, new_prop, type_dict, structure_dict, enum_dict, '#/definitions/')
         new_prop_expected = {
             'type': 'array', 
             'items': {
@@ -157,7 +157,7 @@ class TestRestTypeHandler(unittest.TestCase):
         map_value_type_mock.category = 'GENERIC'
         map_value_type_mock.generic_instantiation = generic_instantiation_map_value_type_mock
         new_prop = {}
-        self.rest_tphandler.visit_generic(generic_instantiation_mock, new_prop, type_dict, structure_dict, enum_dict, '#/definitions/', False )
+        self.rest_tphandler.visit_generic(generic_instantiation_mock, new_prop, type_dict, structure_dict, enum_dict, '#/definitions/')
         new_prop_expected = {
             'type': 'array', 
             'items': {

--- a/test_rest_swagger.py
+++ b/test_rest_swagger.py
@@ -400,19 +400,6 @@ class TestRestMetamodel2Swagger(unittest.TestCase):
 
     rest_meta2swagger = RestMetamodel2Swagger()
 
-    def test_find_consumes(self):
-        # case 1: operation is get or delete
-        mock_method_type = 'get'
-        media_type_actual = self.rest_meta2swagger.find_consumes(mock_method_type)
-        media_type_expected = None
-        self.assertEqual(media_type_expected, media_type_actual)
-
-        # case 2: operation is other than get or delete
-        mock_method_type = 'mock_method'
-        media_type_actual = self.rest_meta2swagger.find_consumes(mock_method_type)
-        media_type_expected = ['application/json']
-        self.assertEqual(media_type_expected, media_type_actual)
-
     def test_post_process_path(self):
         # case 1: adding header parameter in list of parameters 
         # if path equals '/com/vmware/cis/session' and method is 'post

--- a/test_utils.py
+++ b/test_utils.py
@@ -1,0 +1,24 @@
+import unittest
+
+from lib import utils
+
+
+class TestUtils(unittest.TestCase):
+
+    def test_combine_dicts_with_list_values(self):
+        extended = {"1": ["1", "2", "3"],
+                    "2": ["4", "5", "6"]}
+        added = {"3": ["8", "9"],
+                 "2": ["4", "5", "6", "7"]}
+        expected = {"1": ["1", "2", "3"],
+                    "2": ["4", "5", "6", "7"],
+                    "3": ["8", "10"]}
+        utils.combine_dicts_with_list_values(extended, added)
+
+        self.assertEqual(extended.get("1").sort(), expected.get("1").sort())
+        self.assertEqual(extended.get("2").sort(), expected.get("2").sort())
+        self.assertEqual(extended.get("3").sort(), expected.get("3").sort())
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test_utils.py
+++ b/test_utils.py
@@ -10,14 +10,15 @@ class TestUtils(unittest.TestCase):
                     "2": ["4", "5", "6"]}
         added = {"3": ["8", "9"],
                  "2": ["4", "5", "6", "7"]}
-        expected = {"1": ["1", "2", "3"],
-                    "2": ["4", "5", "6", "7"],
-                    "3": ["8", "10"]}
-        utils.combine_dicts_with_list_values(extended, added)
 
-        self.assertEqual(extended.get("1").sort(), expected.get("1").sort())
-        self.assertEqual(extended.get("2").sort(), expected.get("2").sort())
-        self.assertEqual(extended.get("3").sort(), expected.get("3").sort())
+        utils.combine_dicts_with_list_values(extended, added)
+        # Note after combining lists, the original order is not preserved
+        extended.get("1").sort()
+        extended.get("2").sort()
+        extended.get("3").sort()
+        self.assertEqual(extended.get("1"), ["1", "2", "3"])
+        self.assertEqual(extended.get("2"), ["4", "5", "6", "7"])
+        self.assertEqual(extended.get("3"), ["8", "9"])
 
 
 if __name__ == '__main__':

--- a/vmsgen.py
+++ b/vmsgen.py
@@ -35,7 +35,16 @@ DEPRECATE_REST = False
 
 def main():
     # Get user input.
-    metadata_api_url, rest_navigation_url, output_dir, verify, show_unreleased_apis, GENERATE_METAMODEL, SPECIFICATION, GENERATE_UNIQUE_OP_IDS, TAG_SEPARATOR, DEPRECATE_REST = connection.get_input_params()
+    metadata_api_url, \
+    rest_navigation_url, \
+    output_dir, \
+    verify, \
+    show_unreleased_apis, \
+    GENERATE_METAMODEL, \
+    SPECIFICATION, \
+    GENERATE_UNIQUE_OP_IDS, \
+    TAG_SEPARATOR, \
+    DEPRECATE_REST = connection.get_input_params()
     # Maps enumeration id to enumeration info
     enumeration_dict = {}
     # Maps structure_id to structure_info
@@ -73,13 +82,13 @@ def main():
         # package_dict_api holds list of all service urls which come under /api
         # package_dict_deprecated holds a list of all service urls which come under /rest, but are
         # deprecated with /api
-        # replacement_map contains information about the deprecated /rest to /api mappings
-        package_dict_api, package_dict, package_dict_deprecated, replacement_map = dict_processing.add_service_urls_using_metamodel(
+        # replacement_dict contains information about the deprecated /rest to /api mappings
+        package_dict_api, package_dict, package_dict_deprecated, replacement_dict = dict_processing.add_service_urls_using_metamodel(
             service_urls_map, service_dict, rest_navigation_handler, DEPRECATE_REST)
 
         utils.combine_dicts_with_list_values(package_dict, package_dict_deprecated)
 
-        deprecation_handler = RestDeprecationHandler(replacement_map)
+        deprecation_handler = RestDeprecationHandler(replacement_dict)
     else:
         # package_dict_api holds list of all service urls which come under /api
         package_dict_api, package_dict = dict_processing.add_service_urls_using_metamodel(

--- a/vmsgen.py
+++ b/vmsgen.py
@@ -35,7 +35,7 @@ MIXED = False
 
 def main():
     # Get user input.
-    metadata_api_url, rest_navigation_url, output_dir, verify, enable_filtering, GENERATE_METAMODEL, SPECIFICATION, GENERATE_UNIQUE_OP_IDS, TAG_SEPARATOR, MIXED = connection.get_input_params()
+    metadata_api_url, rest_navigation_url, output_dir, verify, show_unreleased_apis, GENERATE_METAMODEL, SPECIFICATION, GENERATE_UNIQUE_OP_IDS, TAG_SEPARATOR, MIXED = connection.get_input_params()
     # Maps enumeration id to enumeration info
     enumeration_dict = {}
     # Maps structure_id to structure_info
@@ -52,7 +52,7 @@ def main():
     session = requests.session()
     session.verify = False
     connector = get_requests_connector(session, url=metadata_api_url)
-    if not enable_filtering:
+    if show_unreleased_apis:
         connector.set_application_context(
             ApplicationContext({SHOW_UNRELEASED_APIS: "True"}))
     print('Connected to ' + metadata_api_url)
@@ -65,9 +65,10 @@ def main():
         service_urls_map,
         rest_navigation_url,
         GENERATE_METAMODEL)
-    if enable_filtering:
-        service_urls_map = dict_processing.get_service_urls_from_rest_navigation(
-            rest_navigation_url, verify)
+
+    # if show_unreleased_apis:
+    #     service_urls_map = dict_processing.get_service_urls_from_rest_navigation(
+    #         rest_navigation_url, verify)
 
     http_error_map = utils.HttpErrorMap(component_svc)
 
@@ -105,7 +106,7 @@ def main():
                 service_urls_map,
                 http_error_map,
                 rest_navigation_handler,
-                enable_filtering,
+                show_unreleased_apis,
                 SPECIFICATION,
                 GENERATE_UNIQUE_OP_IDS,
                 deprecation_handler))
@@ -125,7 +126,7 @@ def main():
                 service_dict,
                 service_urls_map,
                 http_error_map,
-                enable_filtering,
+                show_unreleased_apis,
                 SPECIFICATION,
                 GENERATE_UNIQUE_OP_IDS))
         worker.daemon = True

--- a/vmsgen.py
+++ b/vmsgen.py
@@ -27,15 +27,15 @@ warnings.filterwarnings("ignore")
 
 GENERATE_UNIQUE_OP_IDS = False
 GENERATE_METAMODEL = False
-API_SERVER_HOST = '<vcenter>'
+API_SERVER_HOST = ''
 TAG_SEPARATOR = '/'
 SPECIFICATION = '3'
-MIXED = False
+DEPRECATE_REST = False
 
 
 def main():
     # Get user input.
-    metadata_api_url, rest_navigation_url, output_dir, verify, show_unreleased_apis, GENERATE_METAMODEL, SPECIFICATION, GENERATE_UNIQUE_OP_IDS, TAG_SEPARATOR, MIXED = connection.get_input_params()
+    metadata_api_url, rest_navigation_url, output_dir, verify, show_unreleased_apis, GENERATE_METAMODEL, SPECIFICATION, GENERATE_UNIQUE_OP_IDS, TAG_SEPARATOR, DEPRECATE_REST = connection.get_input_params()
     # Maps enumeration id to enumeration info
     enumeration_dict = {}
     # Maps structure_id to structure_info
@@ -66,20 +66,16 @@ def main():
         rest_navigation_url,
         GENERATE_METAMODEL)
 
-    # if show_unreleased_apis:
-    #     service_urls_map = dict_processing.get_service_urls_from_rest_navigation(
-    #         rest_navigation_url, verify)
-
     http_error_map = utils.HttpErrorMap(component_svc)
 
     deprecation_handler = None
-    if MIXED:
+    if DEPRECATE_REST:
         # package_dict_api holds list of all service urls which come under /api
         # package_dict_deprecated holds a list of all service urls which come under /rest, but are
         # deprecated with /api
         # replacement_map contains information about the deprecated /rest to /api mappings
         package_dict_api, package_dict, package_dict_deprecated, replacement_map = dict_processing.add_service_urls_using_metamodel(
-            service_urls_map, service_dict, rest_navigation_handler, MIXED)
+            service_urls_map, service_dict, rest_navigation_handler, DEPRECATE_REST)
 
         utils.combine_dicts_with_list_values(package_dict, package_dict_deprecated)
 
@@ -87,7 +83,7 @@ def main():
     else:
         # package_dict_api holds list of all service urls which come under /api
         package_dict_api, package_dict = dict_processing.add_service_urls_using_metamodel(
-            service_urls_map, service_dict, rest_navigation_handler, MIXED)
+            service_urls_map, service_dict, rest_navigation_handler, DEPRECATE_REST)
 
     rest = RestUrlProcessing()
     api = ApiUrlProcessing()


### PR DESCRIPTION
Some of the apparent APIs contain Auto REST descriptions (obtained via
the navigation service) or @RequestMapping annotations, both of which
were later on updated with the new @VERB annotations, essentially,
making the old ones deprecated.

The following work introduces a switch - the 'deprecate-slash-rest'
parameter, as described in the README file, which allows generation
of the deprecated APIs. Priorly, the deprecated APIs were not generated 
at all.

Signed-off-by: Anton Obretenov <obretenova@vmware.com>