### PR TITLE
Add /rest in spec by default

### DIFF
--- a/lib/dictionary_processing.py
+++ b/lib/dictionary_processing.py
@@ -100,7 +100,7 @@ def get_all_services_urls(components_urls, verify):
 def add_service_urls_using_metamodel(
         service_urls_map,
         service_dict,
-        rest_navigation_handler: RestNavigationHandler,
+        rest_navigation_handler,
         deprecate_rest=False):
 
     package_dict_api = {}
@@ -170,37 +170,38 @@ def add_service_urls_using_metamodel(
 # They should be separated in different strategies, for each api type - /rest, /api and deprecated (/rest and /api)
 def get_paths_inside_metamodel(service, service_dict, deprecate_rest=False, replacement_dict={}, service_url=None, rest_navigation_handler=None):
     path_list = set()
-    is_rest_api_existing = False
+    has_rest_counterpart = False
     is_in_rest_navigation = False
     is_rest_navigation_checked = False
 
     for operation_id in service_dict[service].operations.keys():
         for request in service_dict[service].operations[operation_id].metadata.keys(
         ):
+            # Is a 7.0 VERB /api check
             if request.lower() in ('post', 'put', 'patch', 'get', 'delete'):
                 path = service_dict[service].operations[operation_id].metadata[request].elements['path'].string_value
-                path_list.add(path)
 
                 # If already found in navigation, no need to check for request mapping
                 if not is_in_rest_navigation:
-                    is_rest_api_existing = check_for_request_mapping_replacement(service_dict[service], operation_id)
+                    has_rest_counterpart = check_for_request_mapping_replacement(service_dict[service], operation_id)
 
-                if not is_rest_api_existing and not is_rest_navigation_checked:
-                    is_rest_api_existing = check_for_rest_navigation_replacement(service_url, rest_navigation_handler)
+                # Check rest navigation if no rest counterpart has been already found and no prior call has been made
+                if not has_rest_counterpart and not is_rest_navigation_checked:
+                    has_rest_counterpart = check_for_rest_navigation_replacement(service_url, rest_navigation_handler)
                     # Add all operations and methods to replacements if it is apparent in rest_navigation
-                    is_in_rest_navigation = is_rest_api_existing
+                    is_in_rest_navigation = has_rest_counterpart
                     is_rest_navigation_checked = True
 
-                if is_rest_api_existing:
+                if has_rest_counterpart:
                     add_replacement_path(service, operation_id, request.lower(), path, replacement_dict)
-                    # If a newer version of the api is included - remove it unless deprecation is on
-                    if not deprecate_rest and not blacklist_utils.is_blacklisted_for_rest(service):
-                        path_list.remove(path)
+
+                if not has_rest_counterpart or deprecate_rest or blacklist_utils.is_blacklisted_for_rest(service):
+                    path_list.add(path)
 
     if path_list == set():
         return ServiceType.SLASH_REST, []
 
-    if is_rest_api_existing:
+    if has_rest_counterpart:
         return ServiceType.SLASH_REST_AND_API, sorted(list(path_list))
 
     return ServiceType.SLASH_API, sorted(list(path_list))

--- a/lib/dictionary_processing.py
+++ b/lib/dictionary_processing.py
@@ -194,7 +194,7 @@ def get_paths_inside_metamodel(service, service_dict, deprecate_rest=False, repl
                 if is_rest_api_existing:
                     add_replacement_path(service, operation_id, request.lower(), path, replacement_dict)
                     # If a newer version of the api is included - remove it unless deprecation is on
-                    if not deprecate_rest:
+                    if not deprecate_rest and not blacklist_utils.is_blacklisted_for_rest(service):
                         path_list.remove(path)
 
     if path_list == set():

--- a/lib/file_output_handler.py
+++ b/lib/file_output_handler.py
@@ -37,7 +37,7 @@ class FileOutputHandler:
         processor.remove_com_vmware_from_dict(path_dict, 0, [], add_camel_case)
         if self.gen_unique_op_id:
             processor.create_unique_op_ids(path_dict)
-        processor.remove_query_params(path_dict)
+        #processor.remove_query_params(path_dict)
         processor.remove_com_vmware_from_dict(type_dict, 0, [], add_camel_case)
 
     def __output_spec(self, package_name, path_dict, type_dict, file_prefix=''):

--- a/test_lib.py
+++ b/test_lib.py
@@ -84,7 +84,7 @@ class TestInputs(unittest.TestCase):
         self.assertEqual(swagger_specification_expected, swagger_specification_actual)
 
         # case 6.1: deprecated option is TRUE
-        test_args = ['vmsgen', '-vc', 'v_url', '-k', '-dsr']
+        test_args = ['vmsgen', '-vc', 'v_url', '-k', '--deprecate-slash-rest']
         deprecated_expected = True
         with mock.patch('sys.argv', test_args):
             _, _, _, _, _, _, _, _, _, deprecated_actual = connection.get_input_params()
@@ -337,7 +337,7 @@ class TestDictionaryProcessing(unittest.TestCase):
         service_dict = {
             'com.vmware.package.mock': service_info_mock
         }
-        # case 1.1: -dsr off
+        # case 1.1: --deprecate-slash-rest off
         package_dict_api_expected = {'package': ['/package/mock']}
         package_dict_api_actual, \
         package_dict_actual, _, _, = dict_processing.add_service_urls_using_metamodel(service_urls_map,
@@ -346,7 +346,7 @@ class TestDictionaryProcessing(unittest.TestCase):
         self.assertEqual(package_dict_api_expected, package_dict_api_actual)
         self.assertEqual({}, package_dict_actual)
 
-        # case 1.2: -dsr on
+        # case 1.2: --deprecate-slash-rest on
         package_dict_api_actual, \
         package_dict_actual, _, _, = dict_processing.add_service_urls_using_metamodel(service_urls_map,
                                                                                       service_dict,
@@ -358,7 +358,7 @@ class TestDictionaryProcessing(unittest.TestCase):
         # case 2: /api operation and /rest equivalent (RestNavigation)
         # Rest navigation returns not None
         rest_navigation_handler.get_service_operations = mock.MagicMock(return_value={})
-        # case 2.1: -dsr off
+        # case 2.1: --deprecate-slash-rest off
         package_dict_api_actual, \
         package_dict_actual, _, _, = dict_processing.add_service_urls_using_metamodel(service_urls_map,
                                                                                       service_dict,
@@ -367,7 +367,7 @@ class TestDictionaryProcessing(unittest.TestCase):
         self.assertEqual({}, package_dict_api_actual)
         self.assertEqual(package_dict_expected, package_dict_actual)
 
-        # case 2.2 -dsr on
+        # case 2.2 --deprecate-slash-rest on
         package_dict_api_actual, \
         package_dict_actual, \
         package_dict_deprecated_actual, _, = dict_processing.add_service_urls_using_metamodel(service_urls_map,
@@ -386,12 +386,12 @@ class TestDictionaryProcessing(unittest.TestCase):
         operation_info_mock.metadata = {
             'mock_element_key': element_info_mock
         }
-        # case 3.1: -dsr off
+        # case 3.1: --deprecate-slash-rest off
         package_dict_expected = {'package': ['/vmware/com/package/mock']}
         _, package_dict_actual, _, _, = dict_processing.add_service_urls_using_metamodel(service_urls_map,
                                                                                          service_dict,
                                                                                          rest_navigation_handler)
-        # case 3.2: -dsr on
+        # case 3.2: --deprecate-slash-rest on
         self.assertEqual(package_dict_expected, package_dict_actual)
         _, package_dict_actual, _, _, = dict_processing.add_service_urls_using_metamodel(service_urls_map,
                                                                                          service_dict,
@@ -407,7 +407,7 @@ class TestDictionaryProcessing(unittest.TestCase):
             'RequestMapping': {}
         }
         package_dict_expected = {'package': ['/vmware/com/package/mock']}
-        # case 4.1: -dsr off
+        # case 4.1: --deprecate-slash-rest off
         package_dict_api_actual, \
         package_dict_actual, \
         package_dict_deprecated_actual, _, = dict_processing.add_service_urls_using_metamodel(service_urls_map,
@@ -418,7 +418,7 @@ class TestDictionaryProcessing(unittest.TestCase):
         self.assertEqual({}, package_dict_api_actual)
         self.assertEqual(package_dict_expected, package_dict_actual)
 
-        # case 4.2: -dsr on
+        # case 4.2: --deprecate-slash-rest on
         package_dict_deprecated_expected = {'package': ['/vmware/com/package/mock']}
         package_dict_api_expected = {'package': ['/package/mock']}
         package_dict_api_actual, \
@@ -439,7 +439,7 @@ class TestDictionaryProcessing(unittest.TestCase):
         }
         service_info_mock.operations['mock-key-2'] = operation_info_mock_second
 
-        # case 5.1: -dsr off
+        # case 5.1: --deprecate-slash-rest off
         package_dict_api_actual, \
         package_dict_actual, \
         package_dict_deprecated_actual, _, = dict_processing.add_service_urls_using_metamodel(service_urls_map,
@@ -448,7 +448,7 @@ class TestDictionaryProcessing(unittest.TestCase):
         package_dict_expected = {'package': ['/vmware/com/package/mock']}
         self.assertEqual(package_dict_expected, package_dict_actual)
 
-        # case 5.2: -dsr on
+        # case 5.2: --deprecate-slash-rest on
         package_dict_deprecated_expected = {'package': ['/vmware/com/package/mock']}
         package_dict_api_expected = {'package': ['/package/mock']}
         package_dict_api_actual, \

--- a/vmsgen.py
+++ b/vmsgen.py
@@ -79,21 +79,17 @@ def main():
     http_error_map = utils.HttpErrorMap(component_svc)
 
     deprecation_handler = None
+
+    # package_dict_api holds list of all service urls which come under /api
+    # package_dict_deprecated holds a list of all service urls which come under /rest, but are
+    # deprecated with /api
+    # replacement_dict contains information about the deprecated /rest to /api mappings
+    package_dict_api, package_dict, package_dict_deprecated, replacement_dict = dict_processing.add_service_urls_using_metamodel(
+        service_urls_map, service_dict, rest_navigation_handler, DEPRECATE_REST)
+
+    utils.combine_dicts_with_list_values(package_dict, package_dict_deprecated)
     if DEPRECATE_REST:
-        # package_dict_api holds list of all service urls which come under /api
-        # package_dict_deprecated holds a list of all service urls which come under /rest, but are
-        # deprecated with /api
-        # replacement_dict contains information about the deprecated /rest to /api mappings
-        package_dict_api, package_dict, package_dict_deprecated, replacement_dict = dict_processing.add_service_urls_using_metamodel(
-            service_urls_map, service_dict, rest_navigation_handler, DEPRECATE_REST)
-
-        utils.combine_dicts_with_list_values(package_dict, package_dict_deprecated)
-
         deprecation_handler = RestDeprecationHandler(replacement_dict)
-    else:
-        # package_dict_api holds list of all service urls which come under /api
-        package_dict_api, package_dict = dict_processing.add_service_urls_using_metamodel(
-            service_urls_map, service_dict, rest_navigation_handler, DEPRECATE_REST)
 
     rest = RestMetadataProcessor()
     api = ApiMetadataProcessor()


### PR DESCRIPTION
Prior this commit /api apis were shown over equivalent /rest apis when
the -disable-slash-rest switch is off. This is incorrect, /rest should
be shown always. This change introduces default /rest apis in spec.

Signed-off-by: Anton Obretenov <obretenova@vmware.com>