### PR TITLE
Add @BodyField processing

### DIFF
--- a/lib/api_endpoint/swagger2/api_swagger_parameter_handler.py
+++ b/lib/api_endpoint/swagger2/api_swagger_parameter_handler.py
@@ -83,7 +83,16 @@ class ApiSwaggerParaHandler():
                 enum_svc,
                 ref_path)
             parameter_obj['description'] = param.documentation
-            body_obj.update(parameter_obj)
+            if 'BodyField' in param.metadata:
+                body_obj['type'] = 'object'
+                body_obj['properties'] = properties_obj
+                properties_obj[param.metadata['BodyField'].elements['name'].string_value] = parameter_obj
+                if 'required' not in parameter_obj:
+                    required.append(param.name)
+                elif parameter_obj['required'] == 'true':
+                    required.append(param.name)
+            else:
+                body_obj.update(parameter_obj)
 
         parameter_obj = {'in': 'body', 'name': 'request_body'}
         if len(required) > 0:

--- a/lib/dictionary_processing.py
+++ b/lib/dictionary_processing.py
@@ -179,6 +179,9 @@ def get_paths_inside_metamodel(service, service_dict, deprecate_rest=False, repl
         ):
             # Is a 7.0 VERB /api check
             if request.lower() in ('post', 'put', 'patch', 'get', 'delete'):
+                if 'path' not in service_dict[service].operations[operation_id].metadata[request].elements:
+                    continue
+
                 path = service_dict[service].operations[operation_id].metadata[request].elements['path'].string_value
 
                 # If already found in navigation, no need to check for request mapping

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -223,7 +223,7 @@ def extract_body_parameters(params):
     body_params = []
     other_params = []
     for param in params:
-        if 'Body' in param.metadata:
+        if 'Body' in param.metadata or 'BodyField' in param.metadata:
             body_params.append(param)
         else:
             other_params.append(param)

--- a/test_api_swagger.py
+++ b/test_api_swagger.py
@@ -19,6 +19,7 @@ class TestApiSwaggerParaHandler(unittest.TestCase):
     field_info_mock.type = field_info_type
     field_info_mock.documentation = 'fieldInfoMockDescription'
     field_info_mock.name = 'fieldInfoMockName'
+    field_info_mock.metadata = {}
     structure_info_mock = mock.Mock()
     structure_info_mock.fields = [field_info_mock]
     structure_dict = {
@@ -65,6 +66,24 @@ class TestApiSwaggerParaHandler(unittest.TestCase):
         parameter_obj_expected = {
             'in': 'body',
             'name': 'request_body',
+            'schema': {'$ref': '#/definitions/ComVmwarePackageMockMockOperationName'}
+        }
+        self.assertEqual(parameter_obj_expected, parameter_obj_actual)
+
+        # validate parameter object by creating json wrappers around body object
+        element_value_mock = mock.Mock()
+        element_value_mock.string_value = 'elementMockName'
+        metadata_mock = mock.Mock()
+        metadata_mock.elements = {"name": element_value_mock}
+
+        self.field_info_mock.metadata = {"BodyField": metadata_mock}
+        parameter_obj_actual = self.api_swagger_parahandler.wrap_body_params('com.vmware.package.mock', 'mockOperationName',
+                                                                           body_param_list, type_dict, self.structure_dict,
+                                                                           self.enum_dict, False)
+        parameter_obj_expected = {
+            'in': 'body',
+            'name': 'request_body',
+            'required': True,
             'schema': {'$ref': '#/definitions/ComVmwarePackageMockMockOperationName'}
         }
         self.assertEqual(parameter_obj_expected, parameter_obj_actual)


### PR DESCRIPTION
Added @BodyField processing, because @BodyFields were inserted as query
parameters in the specification.

NOTE - oas3 requestBody format is not correct - the content key is missing
entirely. This change has not been added to oas3. 

Signed-off-by: Anton Obretenov <obretenova@vmware.com>