### PR TITLE
Add support for the @SerializationName annotation

### DIFF
--- a/lib/type_handler_common.py
+++ b/lib/type_handler_common.py
@@ -148,7 +148,8 @@ class TypeHandlerCommon():
                     structure_svc,
                     enum_svc,
                     ref_path)
-            new_type['properties'].setdefault(field.name, newprop)
+            #new_type['properties'].setdefault(field.name, newprop)
+            new_type['properties'].setdefault(self.get_fieldname(field), newprop)
         required = []
         for property_name, property_value in six.iteritems(
                 new_type['properties']):
@@ -159,6 +160,12 @@ class TypeHandlerCommon():
         if len(required) > 0:
             new_type['required'] = required
         type_dict[type_name] = new_type
+
+    def get_fieldname(self, field):
+        if hasattr(field, "metadata") and "SerializationName" in field.metadata:
+            return field.metadata["SerializationName"].elements["value"].string_value
+        else:
+            return field.name
 
     def get_enum_info(self, type_name, enum_svc):
         if self.show_unreleased_apis:

--- a/test_api_endpoint.py
+++ b/test_api_endpoint.py
@@ -19,7 +19,7 @@ class TestApiTypeHandler(unittest.TestCase):
         generic_instantiation_mock = mock.Mock()
         generic_instantiation_mock.generic_type = 'SET'
         generic_instantiation_mock.element_type = generic_instantiation_element_type_mock
-        
+
         field_info_mock = mock.Mock()
         field_info_type = mock.Mock()
         field_info_type.category = 'BUILTIN'
@@ -28,6 +28,7 @@ class TestApiTypeHandler(unittest.TestCase):
         field_info_mock.generic_instantiation = generic_instantiation_mock
         field_info_mock.documentation = 'fieldInfoMockDescription'
         field_info_mock.name = 'fieldInfoMockName'
+        field_info_mock.metadata = {}
         structure_info_mock = mock.Mock()
         structure_info_mock.fields = [field_info_mock]
         structure_dict = {

--- a/test_lib.py
+++ b/test_lib.py
@@ -1220,6 +1220,12 @@ class TestTypeHandlerCommon(unittest.TestCase):
     
     def test_process_structure_info(self):
         # case 1: processing for field info type as Builtin
+        # @SerializationName override of field name
+        sname_elvalue = mock.Mock()
+        sname_elvalue.string_value = "field_info_mock_name"
+        sname = mock.Mock()
+        sname.elements = {"value": sname_elvalue}
+
         field_info_mock = mock.Mock()
         field_info_type = mock.Mock()
         field_info_type.category = 'BUILTIN'
@@ -1227,6 +1233,7 @@ class TestTypeHandlerCommon(unittest.TestCase):
         field_info_mock.type = field_info_type
         field_info_mock.documentation = 'fieldInfoMockDescription'
         field_info_mock.name = 'fieldInfoMockName'
+        field_info_mock.metadata = {"SerializationName": sname}
         structure_info_mock = mock.Mock()
         structure_info_mock.fields = [field_info_mock]
         structure_dict = {
@@ -1240,12 +1247,12 @@ class TestTypeHandlerCommon(unittest.TestCase):
             'com.vmware.package.mock': {
                 'type': 'object',
                 'properties': {
-                    'fieldInfoMockName': {
+                    'field_info_mock_name': {
                         'description': 'fieldInfoMockDescription',
                         'type': 'date-time'
                     }
                 },
-                'required': ['fieldInfoMockName']
+                'required': ['field_info_mock_name']
             }
         }
         self.assertEqual(type_dict_expected, type_dict)
@@ -1265,6 +1272,7 @@ class TestTypeHandlerCommon(unittest.TestCase):
         field_info_mock.type = field_info_type
         field_info_mock.documentation = 'fieldInfoMockDescription'
         field_info_mock.name = 'fieldInfoMockName'
+        field_info_mock.metadata = {}
         structure_info_mock = mock.Mock()
         structure_info_mock.fields = [field_info_mock]
         structure_dict = {
@@ -1332,6 +1340,7 @@ class TestTypeHandlerCommon(unittest.TestCase):
         field_info_mock.user_defined_type = user_defined_type_mock
         field_info_mock.documentation = 'fieldInfoMockDescription'
         field_info_mock.name = 'fieldInfoMockName'
+        field_info_mock.metadata = {}
         structure_info_mock = mock.Mock()
         structure_info_mock.fields = [field_info_mock]
         structure_dict = {

--- a/test_rest_endpoint.py
+++ b/test_rest_endpoint.py
@@ -27,6 +27,7 @@ class TestRestTypeHandler(unittest.TestCase):
         field_info_mock.generic_instantiation = generic_instantiation_mock
         field_info_mock.documentation = 'fieldInfoMockDescription'
         field_info_mock.name = 'fieldInfoMockName'
+        field_info_mock.metadata = {}
         structure_info_mock = mock.Mock()
         structure_info_mock.fields = [field_info_mock]
         structure_dict = {


### PR DESCRIPTION
This change adds option to replace field name in schemas with the value
of the @SerializationName. 5 tests failed and I fixed them. In one of
the tests I included @SerializationName with a value.

I have also tested against a mock service to mimic CRD.

This covers structure fields. I am unsure if we need additional fixes
for other contexts e.g. query fields. This will come in subsequent
changes.

Signed-off-by: Kiril Karaatanassov <kkaraatanassov@vmware.com>