### PR TITLE
Feature/security finer grained

### DIFF
--- a/lib/api_endpoint/api_metadata_processor.py
+++ b/lib/api_endpoint/api_metadata_processor.py
@@ -27,7 +27,8 @@ class ApiMetadataProcessor(MetadataProcessor):
             service_url_dict,
             http_error_map,
             show_unreleased_apis,
-            spec):
+            spec,
+            auth_navigator):
 
         print('processing package ' + package_name + os.linesep)
         type_dict = {}
@@ -65,6 +66,9 @@ class ApiMetadataProcessor(MetadataProcessor):
                         operation_id,
                         http_error_map,
                         show_unreleased_apis)
+                    scheme_set = auth_navigator.find_schemes_set(operation_id, service_name, package_name)
+                    if scheme_set is not None and len(scheme_set) != 0:
+                        swagg.decorate_path_with_security(path, scheme_set)
                 if spec == '3':
                     path = openapi.get_path(
                         operation_info,

--- a/lib/api_endpoint/swagger2/api_metamodel2swagger.py
+++ b/lib/api_endpoint/swagger2/api_metamodel2swagger.py
@@ -1,4 +1,4 @@
-from lib import utils
+from lib import utils, authentication_metadata_processing
 from lib.api_endpoint.api_metamodel2spec import ApiMetamodel2Spec
 from .api_swagger_parameter_handler import ApiSwaggerParaHandler
 from .api_swagger_response_handler import ApiSwaggerRespHandler
@@ -70,3 +70,9 @@ class ApiMetamodel2Swagger(ApiMetamodel2Spec):
         if path_obj['operationId'].endswith('$task'):
             path_obj['path'] = utils.add_query_param(
                 path_obj['path'], 'vmw-task=true')
+
+    def decorate_path_with_security(self, path_obj, scheme_set):
+        if authentication_metadata_processing.no_authentication_scheme in scheme_set:
+            path_obj["security"] = []
+        elif authentication_metadata_processing.basic_auth_scheme in scheme_set:
+            path_obj["security"] = [{"basic_auth": []}]

--- a/lib/api_endpoint/swagger2/api_metamodel2swagger.py
+++ b/lib/api_endpoint/swagger2/api_metamodel2swagger.py
@@ -72,7 +72,10 @@ class ApiMetamodel2Swagger(ApiMetamodel2Spec):
                 path_obj['path'], 'vmw-task=true')
 
     def decorate_path_with_security(self, path_obj, scheme_set):
-        if authentication_metadata_processing.no_authentication_scheme in scheme_set:
-            path_obj["security"] = []
-        elif authentication_metadata_processing.basic_auth_scheme in scheme_set:
-            path_obj["security"] = [{"basic_auth": []}]
+        security_schemes = []
+        if authentication_metadata_processing.session_id_scheme in scheme_set:
+            security_schemes.append({"session_id": []})
+        if authentication_metadata_processing.basic_auth_scheme in scheme_set:
+            security_schemes.append({"basic_auth": []})
+        if security_schemes:
+            path_obj["security"] = security_schemes

--- a/lib/authentication_metadata_processing.py
+++ b/lib/authentication_metadata_processing.py
@@ -11,6 +11,53 @@ def get_authentication_dict(auth_component_svc):
                 auth_dict[package_name]
 
 
+def get_operation_scheme_top_level(auth_dict, package_name, service_name, operation_name):
+    pass
+
+
+def get_operation_scheme_package_level(auth_component, service_name, operation_name):
+    pass
+
+
+def get_operation_scheme_service_level(auth_component, operation_name):
+    pass
+
+
+def get_operation_scheme(auth_component):
+    pass
+
+
+class AuthenticationComponentBuilder:
+
+    @staticmethod
+    def build_package_level_component(package_info):
+        package_component = AuthenticationComponent()
+        package_component.add_schemes(AuthenticationComponentBuilder.__extract_schemes_list(package_info))
+        for service_name, service_info in six.iteritems(package_info.services):
+            service_component = AuthenticationComponentBuilder.build_service_level_component(service_info)
+            package_component.add_subcomponent(service_component, service_name)
+        return package_component
+
+    @staticmethod
+    def build_service_level_component(service_info):
+        service_component = AuthenticationComponent()
+        service_component.add_schemes(AuthenticationComponentBuilder.__extract_schemes_list(service_info))
+        for operation_name, operation_info in six.iteritems(service_info.operations):
+            operation_component = AuthenticationComponentBuilder.build_operation_level_component(operation_info)
+            service_component.add_subcomponent(operation_component, operation_name)
+        return service_component
+
+    @staticmethod
+    def build_operation_level_component(operation_info):
+        operation_component = AuthenticationComponent()
+        operation_component.add_schemes(AuthenticationComponentBuilder.__extract_schemes_list(operation_info))
+        return operation_component
+
+    @staticmethod
+    def __extract_schemes_list(auth_component):
+        return [auth_info.scheme for auth_info in auth_component.schemes]
+
+
 class AuthenticationComponent:
 
     def __init__(self):
@@ -26,16 +73,14 @@ class AuthenticationComponent:
     def get_subcomponents(self):
         return self.subcomponents_dict
 
-    def add_authentication_component(self, added_auth_component, auth_component_name):
+    def add_subcomponent(self, added_auth_component, auth_component_name):
         if auth_component_name not in self.subcomponents_dict:
             self.subcomponents_dict[auth_component_name] = added_auth_component
         else:
             existing_component = self.subcomponents_dict[auth_component_name]
             existing_component.add_schemes(added_auth_component.get_schemes())
             for name_added_subcomponent, added_subcomponent in six.iteritems(added_auth_component.get_subcomponents()):
-                existing_component.add_authentication_component(added_subcomponent, name_added_subcomponent)
-
-    #def get_
+                existing_component.add_subcomponent(added_subcomponent, name_added_subcomponent)
 
 
 

--- a/lib/authentication_metadata_processing.py
+++ b/lib/authentication_metadata_processing.py
@@ -1,5 +1,9 @@
 import six
 
+# Supproted authentication metadata schemes
+no_authentication_scheme = 'com.vmware.vapi.std.security.no_authentication'
+session_id_scheme = 'com.vmware.vapi.std.security.session_id'
+basic_auth_scheme = 'com.vmware.vapi.std.security.user_pass'
 
 def get_authentication_dict(auth_component_svc):
     auth_dict = {}
@@ -22,27 +26,27 @@ class AuthenticationDictNavigator:
     def __init__(self, auth_dict):
         self.auth_dict = auth_dict
 
-    def find_schemes_list(self, operation_id, service_name, package):
-        component = self.__depth_first_search_component(service_name, package)
+    def find_schemes_set(self, operation_id, service_name, package):
+        component = self.__preorder_depth_first_search_component(service_name, package)
         if component is not None:
             operation_component = component.get_subcomponents_dict().get(operation_id)
             if operation_component is not None:
-                return operation_component.get_schemes_list()
+                return operation_component.get_schemes_set()
             else:
-                return component.get_schemes_list()
+                return component.get_schemes_set()
 
-        service_name = ".".join(service_name.split('.')[-1])
+        service_name = ".".join(service_name.split('.')[:-1])
         while service_name:
-            component = self.__depth_first_search_component(service_name, package)
+            component = self.__preorder_depth_first_search_component(service_name, package)
             if component is not None:
-                return component.get_schemes_list()
+                return component.get_schemes_set()
             else:
-                service_name = ".".join(service_name.split('.')[-1])
+                service_name = ".".join(service_name.split('.')[:-1])
 
         return None
 
 
-    def __depth_first_search_component(self, service_name, package):
+    def __preorder_depth_first_search_component(self, service_name, package):
         if service_name in self.auth_dict:
             return self.auth_dict[service_name]
         else:
@@ -55,7 +59,6 @@ class AuthenticationDictNavigator:
                     return component
 
         return None
-
 
 
 class AuthenticationComponentBuilder:

--- a/lib/authentication_metadata_processing.py
+++ b/lib/authentication_metadata_processing.py
@@ -1,0 +1,44 @@
+import six
+
+
+def get_authentication_dict(auth_component_svc):
+    auth_dict = {}
+    auth_components = auth_component_svc.list()
+    for auth_component in auth_components:
+        auth_component_data = auth_component_svc.get(auth_component)
+        for package_name, package_info in six.iteritems(auth_component_data.info.packages):
+            if package_name in auth_dict:
+                auth_dict[package_name]
+
+
+class AuthenticationComponent:
+
+    def __init__(self):
+        self.scheme_set = set()
+        self.subcomponents_dict = {}
+
+    def add_schemes(self, schemes_iterable):
+        self.scheme_set.update(schemes_iterable)
+
+    def get_schemes(self):
+        return self.scheme_set
+
+    def get_subcomponents(self):
+        return self.subcomponents_dict
+
+    def add_authentication_component(self, added_auth_component, auth_component_name):
+        if auth_component_name not in self.subcomponents_dict:
+            self.subcomponents_dict[auth_component_name] = added_auth_component
+        else:
+            existing_component = self.subcomponents_dict[auth_component_name]
+            existing_component.add_schemes(added_auth_component.get_schemes())
+            for name_added_subcomponent, added_subcomponent in six.iteritems(added_auth_component.get_subcomponents()):
+                existing_component.add_authentication_component(added_subcomponent, name_added_subcomponent)
+
+    #def get_
+
+
+
+
+
+

--- a/lib/authentication_metadata_processing.py
+++ b/lib/authentication_metadata_processing.py
@@ -7,24 +7,55 @@ def get_authentication_dict(auth_component_svc):
     for auth_component in auth_components:
         auth_component_data = auth_component_svc.get(auth_component)
         for package_name, package_info in six.iteritems(auth_component_data.info.packages):
-            if package_name in auth_dict:
-                auth_dict[package_name]
+            if package_name not in auth_dict:
+                auth_dict[package_name] = AuthenticationComponentBuilder.build_package_level_component(package_info)
+            else:
+                new_package_component = AuthenticationComponentBuilder.build_package_level_component(package_info)
+                existing_package_component = auth_dict[package_name]
+                for service_name, service_info in six.iteritems(new_package_component.get_subcomponents_dict()):
+                    existing_package_component.add_subcomponent(service_info, service_name)
+    return auth_dict
 
 
-def get_operation_scheme_top_level(auth_dict, package_name, service_name, operation_name):
-    pass
+class AuthenticationDictNavigator:
+
+    def __init__(self, auth_dict):
+        self.auth_dict = auth_dict
+
+    def find_schemes_list(self, operation_id, service_name, package):
+        component = self.__depth_first_search_component(service_name, package)
+        if component is not None:
+            operation_component = component.get_subcomponents_dict().get(operation_id)
+            if operation_component is not None:
+                return operation_component.get_schemes_list()
+            else:
+                return component.get_schemes_list()
+
+        service_name = ".".join(service_name.split('.')[-1])
+        while service_name:
+            component = self.__depth_first_search_component(service_name, package)
+            if component is not None:
+                return component.get_schemes_list()
+            else:
+                service_name = ".".join(service_name.split('.')[-1])
+
+        return None
 
 
-def get_operation_scheme_package_level(auth_component, service_name, operation_name):
-    pass
+    def __depth_first_search_component(self, service_name, package):
+        if service_name in self.auth_dict:
+            return self.auth_dict[service_name]
+        else:
+            for package_name, package_component in six.iteritems(self.auth_dict):
+                if package not in package_name:
+                    continue
 
+                component = package_component.recursive_search_for_component(service_name)
+                if component is not None:
+                    return component
 
-def get_operation_scheme_service_level(auth_component, operation_name):
-    pass
+        return None
 
-
-def get_operation_scheme(auth_component):
-    pass
 
 
 class AuthenticationComponentBuilder:
@@ -67,10 +98,10 @@ class AuthenticationComponent:
     def add_schemes(self, schemes_iterable):
         self.scheme_set.update(schemes_iterable)
 
-    def get_schemes(self):
+    def get_schemes_set(self):
         return self.scheme_set
 
-    def get_subcomponents(self):
+    def get_subcomponents_dict(self):
         return self.subcomponents_dict
 
     def add_subcomponent(self, added_auth_component, auth_component_name):
@@ -78,12 +109,15 @@ class AuthenticationComponent:
             self.subcomponents_dict[auth_component_name] = added_auth_component
         else:
             existing_component = self.subcomponents_dict[auth_component_name]
-            existing_component.add_schemes(added_auth_component.get_schemes())
-            for name_added_subcomponent, added_subcomponent in six.iteritems(added_auth_component.get_subcomponents()):
+            existing_component.add_schemes(added_auth_component.get_schemes_set())
+            for name_added_subcomponent, added_subcomponent in six.iteritems(added_auth_component.get_subcomponents_dict()):
                 existing_component.add_subcomponent(added_subcomponent, name_added_subcomponent)
 
-
-
-
-
-
+    def recursive_search_for_component(self, component_name):
+        if self.subcomponents_dict == {}:
+            return None
+        elif component_name in self.subcomponents_dict:
+            return self.subcomponents_dict[component_name]
+        else:
+            for _, subcomponent in six.iteritems(self.subcomponents_dict):
+                return subcomponent.recursive_search_for_component(component_name)

--- a/lib/establish_connection.py
+++ b/lib/establish_connection.py
@@ -2,6 +2,7 @@ import argparse
 import os
 from vmware.vapi.stdlib.client.factories import StubConfigurationFactory
 from com.vmware.vapi.metadata import metamodel_client
+from com.vmware.vapi.metadata import authentication_client
 
 
 def get_input_params():
@@ -126,4 +127,9 @@ def get_input_params():
 def get_component_service(connector):
     stub_config = StubConfigurationFactory.new_std_configuration(connector)
     component_svc = metamodel_client.Component(stub_config)
+    return component_svc
+
+def get_authentication_component_service(connector):
+    stub_config = StubConfigurationFactory.new_std_configuration(connector)
+    component_svc = authentication_client.Component(stub_config)
     return component_svc

--- a/lib/rest_endpoint/rest_metadata_processor.py
+++ b/lib/rest_endpoint/rest_metadata_processor.py
@@ -24,6 +24,7 @@ class RestMetadataProcessor(MetadataProcessor):
             rest_navigation_handler,
             show_unreleased_apis,
             spec,
+            auth_navigator,
             deprecation_handler=None):
 
         print('processing package ' + package_name + os.linesep)
@@ -59,6 +60,10 @@ class RestMetadataProcessor(MetadataProcessor):
                             operation_id,
                             http_error_map,
                             show_unreleased_apis)
+                        scheme_set = auth_navigator.find_schemes_set(operation_id, service_name, package_name)
+                        if scheme_set is not None and len(scheme_set) != 0:
+                            swagg.decorate_path_with_security(path, scheme_set)
+
                     if spec == '3':
                         path = openapi.get_path(
                             operation_info,
@@ -120,6 +125,9 @@ class RestMetadataProcessor(MetadataProcessor):
                         operation_id,
                         http_error_map,
                         show_unreleased_apis)
+                    scheme_set = auth_navigator.find_schemes_set(operation_id, service_name, package_name)
+                    if scheme_set is not None and len(scheme_set) != 0:
+                        swagg.decorate_path_with_security(path, scheme_set)
                 if spec == '3':
                     path = openapi.get_path(
                         operation_info,

--- a/lib/rest_endpoint/swagger2/rest_metamodel2swagger.py
+++ b/lib/rest_endpoint/swagger2/rest_metamodel2swagger.py
@@ -1,4 +1,4 @@
-from lib import utils
+from lib import utils, authentication_metadata_processing
 from lib.rest_endpoint.rest_metamodel2spec import RestMetamodel2Spec
 from .rest_swagger_parameter_handler import RestSwaggerParaHandler
 from .rest_swagger_response_handler import RestSwaggerRespHandler
@@ -69,3 +69,9 @@ class RestMetamodel2Swagger(RestMetamodel2Spec):
         if path_obj['operationId'].endswith('$task'):
             path_obj['path'] = utils.add_query_param(
                 path_obj['path'], 'vmw-task=true')
+
+    def decorate_path_with_security(self, path_obj, scheme_set):
+        if authentication_metadata_processing.no_authentication_scheme in scheme_set:
+            path_obj["security"] = []
+        elif authentication_metadata_processing.basic_auth_scheme in scheme_set:
+            path_obj["security"] = [{"basic_auth": []}]

--- a/lib/rest_endpoint/swagger2/rest_metamodel2swagger.py
+++ b/lib/rest_endpoint/swagger2/rest_metamodel2swagger.py
@@ -71,7 +71,10 @@ class RestMetamodel2Swagger(RestMetamodel2Spec):
                 path_obj['path'], 'vmw-task=true')
 
     def decorate_path_with_security(self, path_obj, scheme_set):
-        if authentication_metadata_processing.no_authentication_scheme in scheme_set:
-            path_obj["security"] = []
-        elif authentication_metadata_processing.basic_auth_scheme in scheme_set:
-            path_obj["security"] = [{"basic_auth": []}]
+        security_schemes = []
+        if authentication_metadata_processing.session_id_scheme in scheme_set:
+            security_schemes.append({"session_id": []})
+        if authentication_metadata_processing.basic_auth_scheme in scheme_set:
+            security_schemes.append({"basic_auth": []})
+        if security_schemes:
+            path_obj["security"] = security_schemes

--- a/lib/swagger_final_path_processing.py
+++ b/lib/swagger_final_path_processing.py
@@ -33,8 +33,19 @@ class SwaggerPathProcessing(PathProcessing):
                 'version': '2.0.0'},
             'host': '<vcenter>',
             'securityDefinitions': {
+                "api_key": {
+                    "in": "header",
+                    "name": "vmware-api-session-id",
+                    "type": "apiKey"
+                },
                 'basic_auth': {
-                    'type': 'basic'}},
+                    'type': 'basic'
+                }},
+            "security": [
+                {
+                    "api_key": []
+                }
+            ],
             'basePath': '',
             'produces': [
                 'application/json'

--- a/lib/swagger_final_path_processing.py
+++ b/lib/swagger_final_path_processing.py
@@ -33,7 +33,7 @@ class SwaggerPathProcessing(PathProcessing):
                 'version': '2.0.0'},
             'host': '<vcenter>',
             'securityDefinitions': {
-                "api_key": {
+                "session_id": {
                     "in": "header",
                     "name": "vmware-api-session-id",
                     "type": "apiKey"
@@ -41,11 +41,6 @@ class SwaggerPathProcessing(PathProcessing):
                 'basic_auth': {
                     'type': 'basic'
                 }},
-            "security": [
-                {
-                    "api_key": []
-                }
-            ],
             'basePath': '',
             'produces': [
                 'application/json'

--- a/test_authentication_metadata_processing.py
+++ b/test_authentication_metadata_processing.py
@@ -1,11 +1,12 @@
 import unittest
 
 from lib.authentication_metadata_processing import AuthenticationComponent
-
+from lib.authentication_metadata_processing import AuthenticationComponentBuilder
+from unittest import mock
 
 class TestAuthenticationComponent(unittest.TestCase):
 
-    def test_authentication_component_operations(self):
+    def test_authentication_component(self):
         package_level_auth_component = AuthenticationComponent()
         package_level_auth_component.add_schemes(["basic_auth"])
 
@@ -14,7 +15,7 @@ class TestAuthenticationComponent(unittest.TestCase):
 
         service_level_auth_component = AuthenticationComponent()
         service_level_auth_component.add_schemes(["token"])
-        package_level_auth_component.add_authentication_component(service_level_auth_component, "my.token.auth.service")
+        package_level_auth_component.add_subcomponent(service_level_auth_component, "my.token.auth.service")
 
         subcomponents_dict = package_level_auth_component.get_subcomponents()
         expected_subcomponent_scheme = {"token"}
@@ -24,9 +25,9 @@ class TestAuthenticationComponent(unittest.TestCase):
         operation_level_auth_component.add_schemes(["saml_token"])
         service_level_auth_component_updated = AuthenticationComponent()
         service_level_auth_component_updated.add_schemes({"token", "oauth2"})
-        service_level_auth_component_updated.add_authentication_component(operation_level_auth_component,
+        service_level_auth_component_updated.add_subcomponent(operation_level_auth_component,
                                                                           "my.token.auth.service.list")
-        package_level_auth_component.add_authentication_component(service_level_auth_component_updated,
+        package_level_auth_component.add_subcomponent(service_level_auth_component_updated,
                                                                   "my.token.auth.service")
 
         expected_subcomponent_scheme = {"token", "oauth2"}
@@ -34,11 +35,11 @@ class TestAuthenticationComponent(unittest.TestCase):
 
         operation_level_auth_component_updated = AuthenticationComponent()
         operation_level_auth_component_updated.add_schemes(["session_id"])
-        service_level_auth_component_updated.add_authentication_component(operation_level_auth_component_updated,
+        service_level_auth_component_updated.add_subcomponent(operation_level_auth_component_updated,
                                                                           "my.token.auth.service.list")
-        service_level_auth_component_updated.add_authentication_component(operation_level_auth_component_updated,
+        service_level_auth_component_updated.add_subcomponent(operation_level_auth_component_updated,
                                                                           "my.token.auth.service.create")
-        package_level_auth_component.add_authentication_component(service_level_auth_component_updated,
+        package_level_auth_component.add_subcomponent(service_level_auth_component_updated,
                                                                   "my.token.auth.service")
 
         subcomponents_dict = package_level_auth_component.get_subcomponents()
@@ -51,6 +52,31 @@ class TestAuthenticationComponent(unittest.TestCase):
                          {"session_id"})
 
 
+    def test_authentication_component_builder(self):
+        session_id_auth_info_mock = mock.Mock()
+        session_id_auth_info_mock.scheme = "session_id"
+        token_auth_info_mock = mock.Mock()
+        token_auth_info_mock.scheme = "token"
+        oauth_auth_info_mock = mock.Mock()
+        oauth_auth_info_mock.scheme = "oauth"
+        operation_info_mock = mock.Mock()
+        operation_info_mock.schemes = [session_id_auth_info_mock, token_auth_info_mock]
+        service_info_mock = mock.Mock()
+        service_info_mock.schemes = [token_auth_info_mock, oauth_auth_info_mock]
+        service_info_mock.operations = {"create": operation_info_mock}
+        package_info_mock = mock.Mock()
+        package_info_mock.services = {"com.vmware.cis.session": service_info_mock}
+        package_info_mock.schemes = [oauth_auth_info_mock, session_id_auth_info_mock]
+
+        package_component = AuthenticationComponentBuilder.build_package_level_component(package_info_mock)
+        expected_package_level_set = {"oauth", "session_id"}
+        self.assertEqual(package_component.get_schemes(), expected_package_level_set)
+        service_component = package_component.get_subcomponents()["com.vmware.cis.session"]
+        expected_schemes = {"oauth", "token"}
+        self.assertEqual(service_component.get_schemes(), expected_schemes)
+        operation_component = service_component.get_subcomponents()["create"]
+        expected_schemes = {"session_id", "token"}
+        self.assertEqual(operation_component.get_schemes(), expected_schemes)
 
 if __name__ == '__main__':
     unittest.main()

--- a/test_authentication_metadata_processing.py
+++ b/test_authentication_metadata_processing.py
@@ -25,16 +25,14 @@ class TestAuthenticationComponent(unittest.TestCase):
         package_level_auth_component = AuthenticationComponent()
         package_level_auth_component.add_schemes(["basic_auth"])
 
-        expected_scheme = {"basic_auth"}
-        self.assertEqual(package_level_auth_component.get_schemes_set(), expected_scheme)
+        self.assertEqual({"basic_auth"}, package_level_auth_component.get_schemes_set())
 
         service_level_auth_component = AuthenticationComponent()
         service_level_auth_component.add_schemes(["token"])
         package_level_auth_component.add_subcomponent(service_level_auth_component, "my.token.auth.service")
 
         subcomponents_dict = package_level_auth_component.get_subcomponents_dict()
-        expected_subcomponent_scheme = {"token"}
-        self.assertEqual(subcomponents_dict.get("my.token.auth.service").get_schemes_set(), expected_subcomponent_scheme)
+        self.assertEqual({"token"}, subcomponents_dict.get("my.token.auth.service").get_schemes_set())
         
         operation_level_auth_component = AuthenticationComponent()
         operation_level_auth_component.add_schemes(["saml_token"])
@@ -45,8 +43,7 @@ class TestAuthenticationComponent(unittest.TestCase):
         package_level_auth_component.add_subcomponent(service_level_auth_component_updated,
                                                                   "my.token.auth.service")
 
-        expected_subcomponent_scheme = {"token", "oauth2"}
-        self.assertEqual(subcomponents_dict.get("my.token.auth.service").get_schemes_set(), expected_subcomponent_scheme)
+        self.assertEqual({"token", "oauth2"}, subcomponents_dict.get("my.token.auth.service").get_schemes_set())
 
         operation_level_auth_component_updated = AuthenticationComponent()
         operation_level_auth_component_updated.add_schemes(["session_id"])
@@ -59,12 +56,12 @@ class TestAuthenticationComponent(unittest.TestCase):
 
         subcomponents_dict = package_level_auth_component.get_subcomponents_dict()
         operation_level_subcomponents_dict = subcomponents_dict.get("my.token.auth.service").get_subcomponents_dict()
-        self.assertEqual(len(operation_level_subcomponents_dict), 2)
+        self.assertEqual(2, len(operation_level_subcomponents_dict))
 
-        self.assertEqual(operation_level_subcomponents_dict.get("my.token.auth.service.list").get_schemes_set(),
-                         {"session_id", "saml_token"})
-        self.assertEqual(operation_level_subcomponents_dict.get("my.token.auth.service.create").get_schemes_set(),
-                         {"session_id"})
+        self.assertEqual({"session_id", "saml_token"},
+                         operation_level_subcomponents_dict.get("my.token.auth.service.list").get_schemes_set())
+        self.assertEqual({"session_id"},
+                         operation_level_subcomponents_dict.get("my.token.auth.service.create").get_schemes_set())
 
 
         found_component = package_level_auth_component.recursive_search_for_component("my.token.auth.service.list")
@@ -75,14 +72,11 @@ class TestAuthenticationComponent(unittest.TestCase):
 
     def test_authentication_component_builder(self):
         package_component = AuthenticationComponentBuilder.build_package_level_component(self.package_info_mock)
-        expected_package_level_set = {"oauth", "session_id"}
-        self.assertEqual(package_component.get_schemes_set(), expected_package_level_set)
+        self.assertEqual({"oauth", "session_id"}, package_component.get_schemes_set())
         service_component = package_component.get_subcomponents_dict()["com.vmware.cis.session"]
-        expected_schemes = {"oauth", "token"}
-        self.assertEqual(service_component.get_schemes_set(), expected_schemes)
+        self.assertEqual({"oauth", "token"}, service_component.get_schemes_set())
         operation_component = service_component.get_subcomponents_dict()["create"]
-        expected_schemes = {"session_id", "token"}
-        self.assertEqual(operation_component.get_schemes_set(), expected_schemes)
+        self.assertEqual({"session_id", "token"}, operation_component.get_schemes_set())
 
 
     def test_authentication_dict_navigator(self):

--- a/test_authentication_metadata_processing.py
+++ b/test_authentication_metadata_processing.py
@@ -1,0 +1,56 @@
+import unittest
+
+from lib.authentication_metadata_processing import AuthenticationComponent
+
+
+class TestAuthenticationComponent(unittest.TestCase):
+
+    def test_authentication_component_operations(self):
+        package_level_auth_component = AuthenticationComponent()
+        package_level_auth_component.add_schemes(["basic_auth"])
+
+        expected_scheme = {"basic_auth"}
+        self.assertEqual(package_level_auth_component.get_schemes(), expected_scheme)
+
+        service_level_auth_component = AuthenticationComponent()
+        service_level_auth_component.add_schemes(["token"])
+        package_level_auth_component.add_authentication_component(service_level_auth_component, "my.token.auth.service")
+
+        subcomponents_dict = package_level_auth_component.get_subcomponents()
+        expected_subcomponent_scheme = {"token"}
+        self.assertEqual(subcomponents_dict.get("my.token.auth.service").get_schemes(), expected_subcomponent_scheme)
+        
+        operation_level_auth_component = AuthenticationComponent()
+        operation_level_auth_component.add_schemes(["saml_token"])
+        service_level_auth_component_updated = AuthenticationComponent()
+        service_level_auth_component_updated.add_schemes({"token", "oauth2"})
+        service_level_auth_component_updated.add_authentication_component(operation_level_auth_component,
+                                                                          "my.token.auth.service.list")
+        package_level_auth_component.add_authentication_component(service_level_auth_component_updated,
+                                                                  "my.token.auth.service")
+
+        expected_subcomponent_scheme = {"token", "oauth2"}
+        self.assertEqual(subcomponents_dict.get("my.token.auth.service").get_schemes(), expected_subcomponent_scheme)
+
+        operation_level_auth_component_updated = AuthenticationComponent()
+        operation_level_auth_component_updated.add_schemes(["session_id"])
+        service_level_auth_component_updated.add_authentication_component(operation_level_auth_component_updated,
+                                                                          "my.token.auth.service.list")
+        service_level_auth_component_updated.add_authentication_component(operation_level_auth_component_updated,
+                                                                          "my.token.auth.service.create")
+        package_level_auth_component.add_authentication_component(service_level_auth_component_updated,
+                                                                  "my.token.auth.service")
+
+        subcomponents_dict = package_level_auth_component.get_subcomponents()
+        operation_level_subcomponents_dict = subcomponents_dict.get("my.token.auth.service").get_subcomponents()
+        self.assertEqual(len(operation_level_subcomponents_dict), 2)
+
+        self.assertEqual(operation_level_subcomponents_dict.get("my.token.auth.service.list").get_schemes(),
+                         {"session_id", "saml_token"})
+        self.assertEqual(operation_level_subcomponents_dict.get("my.token.auth.service.create").get_schemes(),
+                         {"session_id"})
+
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This changes introduces a global session_id security, which is overriden per operation when basic_auth or no_authentication is detected in the metadata of the associated operation. 

The new functionality utilizes the authentication metadata service - since more requests are made to an external API, execution time is slower with around 15 sec (as tested on my local machine)