### PR TITLE
Optimize generation time

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Generated swagger files at output for https://vcip/api in 106.460405666999577 se
 Running the above command generates the openAPI specification files (3.0) by default. In order to generate the swagger 2.0 specification files, the parameter -oas needs to passed explicitly.
 
 The description of the input parameters that can go in the run command is as follows:
-1. **metadata-url** : It is the url of the metadata API. If IP address of the vCenter (vcip) is provided, it takes in the values as **https://< vcip >/api**
+1. **metadata-url**: It is the url of the metadata API. If IP address of the vCenter (vcip) is provided, it takes in the values as **https://< vcip >/api**
 2. **rest-navigation-url**: This is the url for rest navigation. If vcip is provided this url becomes **https://< vcip >/rest**
 3. **vcip**: It is the IP Address of the vCenter server. It is used to specify the metadata-url and rest-navigation-url.
 4. **output**: This is output directory where the generated swagger or openapi files will be stored. If the output directory is not supplied, the present working directory is chosen as the output directory.
@@ -41,7 +41,9 @@ The description of the input parameters that can go in the run command is as fol
 8. **metamodel-components**: If this parameter is passed, then each metamodel component retreived from the vCenter server is saved in a different .json file under the metamodel directory.
 9. **host**: It is the IP Address of the host that serves the API. By default the value is < vcenter >
 10. **oas** : This parameter is used to specify as to which version of swagger file the user wants to generate. By default the generated files are of version 3 i.e openapi. If the user wants to generate the version 2 files, the parameter needs to be passed explicitly.
-11. **deprecate-slash-rest** : This parameter is used to deprecate the /rest APIs in the generated OpenAPI specification, only when the API to deprecate has an /api counterpart.
+11. **deprecate-slash-rest**: This parameter is used to deprecate the /rest APIs in the generated OpenAPI specification, only when the API to deprecate has an /api counterpart.
+12. **fetch-authentication-metadata**: Authentication information per operation is retrieved via the authentication metadata service, which contributes to the total generation time. This parameter is used to specify whether the authentication information is going to be retrieved. 
+13. **auto-rest-services**: The parameter is used to acquire the 6.0 Auto Rest services. Following the parameter are space separated service IDs.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -42,8 +42,7 @@ The description of the input parameters that can go in the run command is as fol
 9. **host**: It is the IP Address of the host that serves the API. By default the value is < vcenter >
 10. **oas** : This parameter is used to specify as to which version of swagger file the user wants to generate. By default the generated files are of version 3 i.e openapi. If the user wants to generate the version 2 files, the parameter needs to be passed explicitly.
 11. **deprecate-slash-rest**: This parameter is used to deprecate the /rest APIs in the generated OpenAPI specification, only when the API to deprecate has an /api counterpart.
-12. **fetch-authentication-metadata**: Authentication information per operation is retrieved via the authentication metadata service, which contributes to the total generation time. This parameter is used to specify whether the authentication information is going to be retrieved. 
-13. **auto-rest-services**: The parameter is used to acquire the 6.0 Auto Rest services. Following the parameter are space separated service IDs.
+12. **fetch-authentication-metadata**: Adds security information in the generated OpenAPI definitions. In order to do that it accesses API authentication metadata, which increases the processing time (~20-30 seconds).
 
 ## Contributing
 

--- a/lib/api_endpoint/api_metadata_processor.py
+++ b/lib/api_endpoint/api_metadata_processor.py
@@ -29,7 +29,7 @@ class ApiMetadataProcessor(MetadataProcessor):
             http_error_map,
             show_unreleased_apis,
             spec,
-            auth_navigator):
+            auth_navigator=None):
 
         print('processing package ' + package_name + os.linesep)
         type_dict = {}
@@ -67,9 +67,10 @@ class ApiMetadataProcessor(MetadataProcessor):
                         operation_id,
                         http_error_map,
                         show_unreleased_apis)
-                    scheme_set = auth_navigator.find_schemes_set(operation_id, service_name, package_name)
-                    if scheme_set is not None and len(scheme_set) != 0:
-                        swagg.decorate_path_with_security(path, scheme_set)
+                    if auth_navigator is not None:
+                        scheme_set = auth_navigator.find_schemes_set(operation_id, service_name, package_name)
+                        if scheme_set is not None and len(scheme_set) != 0:
+                            swagg.decorate_path_with_security(path, scheme_set)
                 if spec == '3':
                     path = openapi.get_path(
                         operation_info,

--- a/lib/dictionary_processing.py
+++ b/lib/dictionary_processing.py
@@ -103,6 +103,7 @@ def add_service_urls_using_metamodel(
         service_urls_map,
         service_dict,
         rest_navigation_handler,
+        auto_rest_services,
         deprecate_rest=False):
 
     package_dict_api = {}
@@ -124,6 +125,7 @@ def add_service_urls_using_metamodel(
     for service in service_dict:
         service_type, path_list = get_paths_inside_metamodel(service,
                                                              service_dict,
+                                                             auto_rest_services,
                                                              deprecate_rest,
                                                              replacement_dict)
         if (service_type in [ServiceType.SLASH_API, ServiceType.SLASH_REST_AND_API]) and not blacklist_utils.is_blacklisted_for_api(service):
@@ -168,7 +170,7 @@ def add_service_urls_using_metamodel(
 
 #TODO the overly complicated method below along with add_service_urls_using_metamodel should be refactored
 # They should be separated in different strategies, for each api type - /rest, /api and deprecated (/rest and /api)
-def get_paths_inside_metamodel(service, service_dict, deprecate_rest=False, replacement_dict={}):
+def get_paths_inside_metamodel(service, service_dict, auto_rest_services, deprecate_rest=False, replacement_dict={}):
     path_list = set()
     has_rest_counterpart = False
     is_in_rest_navigation = False
@@ -190,7 +192,7 @@ def get_paths_inside_metamodel(service, service_dict, deprecate_rest=False, repl
 
                 # Check rest navigation if no rest counterpart has been already found and no prior call has been made
                 if not has_rest_counterpart and not is_rest_navigation_checked:
-                    has_rest_counterpart = utils.is_service_auto_rest(service)
+                    has_rest_counterpart = service in auto_rest_services
                     # Add all operations and methods to replacements if it is apparent in rest_navigation
                     is_in_rest_navigation = has_rest_counterpart
                     is_rest_navigation_checked = True

--- a/lib/dictionary_processing.py
+++ b/lib/dictionary_processing.py
@@ -125,9 +125,7 @@ def add_service_urls_using_metamodel(
         service_type, path_list = get_paths_inside_metamodel(service,
                                                              service_dict,
                                                              deprecate_rest,
-                                                             replacement_dict,
-                                                             rest_services.get(service, None),
-                                                             rest_navigation_handler)
+                                                             replacement_dict)
         if (service_type in [ServiceType.SLASH_API, ServiceType.SLASH_REST_AND_API]) and not blacklist_utils.is_blacklisted_for_api(service):
             for path in path_list:
                 service_urls_map[path] = (service, '/api')
@@ -170,7 +168,7 @@ def add_service_urls_using_metamodel(
 
 #TODO the overly complicated method below along with add_service_urls_using_metamodel should be refactored
 # They should be separated in different strategies, for each api type - /rest, /api and deprecated (/rest and /api)
-def get_paths_inside_metamodel(service, service_dict, deprecate_rest=False, replacement_dict={}, service_url=None, rest_navigation_handler=None):
+def get_paths_inside_metamodel(service, service_dict, deprecate_rest=False, replacement_dict={}):
     path_list = set()
     has_rest_counterpart = False
     is_in_rest_navigation = False
@@ -192,7 +190,7 @@ def get_paths_inside_metamodel(service, service_dict, deprecate_rest=False, repl
 
                 # Check rest navigation if no rest counterpart has been already found and no prior call has been made
                 if not has_rest_counterpart and not is_rest_navigation_checked:
-                    has_rest_counterpart = check_for_rest_navigation_replacement(service_url, rest_navigation_handler)
+                    has_rest_counterpart = utils.is_service_auto_rest(service)
                     # Add all operations and methods to replacements if it is apparent in rest_navigation
                     is_in_rest_navigation = has_rest_counterpart
                     is_rest_navigation_checked = True
@@ -216,15 +214,6 @@ def check_for_request_mapping_replacement(service, operation_id):
     # Check whether the service contains both @RequestMapping and @Verb annotations
     if 'RequestMapping' in service.operations[operation_id].metadata.keys():
         return True
-    return False
-
-
-def check_for_rest_navigation_replacement(service_url, rest_navigation_handler):
-    if service_url is not None and rest_navigation_handler is not None:
-        # Check whether the service is apparent in the rest navigation - has 6.0
-        service_operations = rest_navigation_handler.get_service_operations(service_url)
-        if service_operations is not None:
-            return True
     return False
 
 

--- a/lib/dictionary_processing.py
+++ b/lib/dictionary_processing.py
@@ -127,7 +127,9 @@ def add_service_urls_using_metamodel(
                                                              service_dict,
                                                              auto_rest_services,
                                                              deprecate_rest,
-                                                             replacement_dict)
+                                                             replacement_dict,
+                                                             rest_services.get(service, None),
+                                                             rest_navigation_handler)
         if (service_type in [ServiceType.SLASH_API, ServiceType.SLASH_REST_AND_API]) and not blacklist_utils.is_blacklisted_for_api(service):
             for path in path_list:
                 service_urls_map[path] = (service, '/api')
@@ -170,7 +172,13 @@ def add_service_urls_using_metamodel(
 
 #TODO the overly complicated method below along with add_service_urls_using_metamodel should be refactored
 # They should be separated in different strategies, for each api type - /rest, /api and deprecated (/rest and /api)
-def get_paths_inside_metamodel(service, service_dict, auto_rest_services, deprecate_rest=False, replacement_dict={}):
+def get_paths_inside_metamodel(service,
+                               service_dict,
+                               auto_rest_services,
+                               deprecate_rest=False,
+                               replacement_dict={},
+                               service_url=None,
+                               rest_navigation_handler=None):
     path_list = set()
     has_rest_counterpart = False
     is_in_rest_navigation = False
@@ -192,7 +200,10 @@ def get_paths_inside_metamodel(service, service_dict, auto_rest_services, deprec
 
                 # Check rest navigation if no rest counterpart has been already found and no prior call has been made
                 if not has_rest_counterpart and not is_rest_navigation_checked:
-                    has_rest_counterpart = service in auto_rest_services
+                    if auto_rest_services:
+                        has_rest_counterpart = service in auto_rest_services
+                    else:
+                        has_rest_counterpart = check_for_rest_navigation_replacement(service_url, rest_navigation_handler)
                     # Add all operations and methods to replacements if it is apparent in rest_navigation
                     is_in_rest_navigation = has_rest_counterpart
                     is_rest_navigation_checked = True
@@ -216,6 +227,14 @@ def check_for_request_mapping_replacement(service, operation_id):
     # Check whether the service contains both @RequestMapping and @Verb annotations
     if 'RequestMapping' in service.operations[operation_id].metadata.keys():
         return True
+    return False
+
+def check_for_rest_navigation_replacement(service_url, rest_navigation_handler):
+    if service_url is not None and rest_navigation_handler is not None:
+        # Check whether the service is apparent in the rest navigation - has 6.0
+        service_operations = rest_navigation_handler.get_service_operations(service_url)
+        if service_operations is not None:
+            return True
     return False
 
 

--- a/lib/establish_connection.py
+++ b/lib/establish_connection.py
@@ -81,6 +81,15 @@ def get_input_params():
         default=False,
         dest='deprecate_rest',
         help='/api and /rest rendering - with /rest being deprecated')
+    parser.add_argument(
+        '-fam',
+        '--fetch-authentication-metadata',
+        required=False,
+        nargs='?',
+        const=True,
+        default=False,
+        dest='fetch_auth_metadata',
+        help='retrieves authentication information from the authentication metadata service')
     args = parser.parse_args()
     metadata_url = args.metadata_url
     rest_navigation_url = args.rest_navigation_url
@@ -124,7 +133,19 @@ def get_input_params():
     global DEPRECATE_REST
     DEPRECATE_REST = args.deprecate_rest
 
-    return metadata_url, rest_navigation_url, output_dir, verify, show_unreleased_apis, GENERATE_METAMODEL, SPECIFICATION, GENERATE_UNIQUE_OP_IDS, TAG_SEPARATOR, DEPRECATE_REST
+    fetch_auth_metadata = args.fetch_auth_metadata
+
+    return metadata_url,\
+           rest_navigation_url,\
+           output_dir,\
+           verify,\
+           show_unreleased_apis,\
+           GENERATE_METAMODEL,\
+           SPECIFICATION,\
+           GENERATE_UNIQUE_OP_IDS,\
+           TAG_SEPARATOR,\
+           DEPRECATE_REST,\
+           fetch_auth_metadata
 
 
 def get_component_service(connector):

--- a/lib/establish_connection.py
+++ b/lib/establish_connection.py
@@ -90,6 +90,13 @@ def get_input_params():
         default=False,
         dest='fetch_auth_metadata',
         help='retrieves authentication information from the authentication metadata service')
+    parser.add_argument(
+        '-ars'
+        '--auto-rest-services',
+        nargs='+',
+        default=[],
+        dest='auto_rest_services',
+        help='list of services described with auto rest')
     args = parser.parse_args()
     metadata_url = args.metadata_url
     rest_navigation_url = args.rest_navigation_url
@@ -135,6 +142,8 @@ def get_input_params():
 
     fetch_auth_metadata = args.fetch_auth_metadata
 
+    auto_rest_services = args.auto_rest_services
+
     return metadata_url,\
            rest_navigation_url,\
            output_dir,\
@@ -145,7 +154,8 @@ def get_input_params():
            GENERATE_UNIQUE_OP_IDS,\
            TAG_SEPARATOR,\
            DEPRECATE_REST,\
-           fetch_auth_metadata
+           fetch_auth_metadata,\
+           auto_rest_services
 
 
 def get_component_service(connector):

--- a/lib/rest_endpoint/rest_metadata_processor.py
+++ b/lib/rest_endpoint/rest_metadata_processor.py
@@ -27,7 +27,7 @@ class RestMetadataProcessor(MetadataProcessor):
             rest_navigation_handler,
             show_unreleased_apis,
             spec,
-            auth_navigator,
+            auth_navigator=None,
             deprecation_handler=None):
 
         print('processing package ' + package_name + os.linesep)
@@ -63,9 +63,11 @@ class RestMetadataProcessor(MetadataProcessor):
                             operation_id,
                             http_error_map,
                             show_unreleased_apis)
-                        scheme_set = auth_navigator.find_schemes_set(operation_id, service_name, package_name)
-                        if scheme_set is not None and len(scheme_set) != 0:
-                            swagg.decorate_path_with_security(path, scheme_set)
+
+                        if auth_navigator is not None:
+                            scheme_set = auth_navigator.find_schemes_set(operation_id, service_name, package_name)
+                            if scheme_set is not None and len(scheme_set) != 0:
+                                swagg.decorate_path_with_security(path, scheme_set)
 
                     if spec == '3':
                         path = openapi.get_path(
@@ -128,9 +130,12 @@ class RestMetadataProcessor(MetadataProcessor):
                         operation_id,
                         http_error_map,
                         show_unreleased_apis)
-                    scheme_set = auth_navigator.find_schemes_set(operation_id, service_name, package_name)
-                    if scheme_set is not None and len(scheme_set) != 0:
-                        swagg.decorate_path_with_security(path, scheme_set)
+
+                    if auth_navigator is not None:
+                        scheme_set = auth_navigator.find_schemes_set(operation_id, service_name, package_name)
+                        if scheme_set is not None and len(scheme_set) != 0:
+                            swagg.decorate_path_with_security(path, scheme_set)
+
                 if spec == '3':
                     path = openapi.get_path(
                         operation_info,

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -312,54 +312,6 @@ def create_req_body_from_params_list(path_obj):
             del parameters[index]
 
 
-auto_rest_services = ['com.vmware.vcenter.ovf.import_flag',
-                      'com.vmware.vcenter.ovf.export_flag',
-                      'com.vmware.vcenter.ovf.library_item',
-                      'com.vmware.cis.session',
-                      'com.vmware.vcenter.inventory.datastore',
-                      'com.vmware.vcenter.inventory.network',
-                      'com.vmware.cis.tagging.tag_association',
-                      'com.vmware.cis.tagging.category',
-                      'com.vmware.cis.tagging.tag',
-                      'com.vmware.vapi.metadata.metamodel.service.operation',
-                      'com.vmware.vapi.metadata.cli.command',
-                      'com.vmware.vapi.metadata.cli.namespace',
-                      'com.vmware.vapi.metadata.metamodel.package',
-                      'com.vmware.vapi.metadata.metamodel.service',
-                      'com.vmware.vapi.metadata.metamodel.structure',
-                      'com.vmware.vapi.metadata.metamodel.enumeration',
-                      'com.vmware.vapi.metadata.metamodel.component',
-                      'com.vmware.vapi.metadata.metamodel.resource',
-                      'com.vmware.vapi.metadata.metamodel.resource.model',
-                      'com.vmware.vapi.metadata.authentication.service.operation',
-                      'com.vmware.vapi.metadata.authentication.service',
-                      'com.vmware.vapi.metadata.authentication.component',
-                      'com.vmware.vapi.metadata.authentication.package',
-                      'com.vmware.vapi.metadata.privilege.component',
-                      'com.vmware.vapi.metadata.privilege.package',
-                      'com.vmware.vapi.metadata.privilege.service',
-                      'com.vmware.vapi.metadata.privilege.service.operation',
-                      'com.vmware.content.library',
-                      'com.vmware.content.local_library',
-                      'com.vmware.content.configuration',
-                      'com.vmware.content.subscribed_library',
-                      'com.vmware.content.type',
-                      'com.vmware.content.library.subscribed_item',
-                      'com.vmware.content.library.item',
-                      'com.vmware.content.library.subscriptions',
-                      'com.vmware.content.library.item.update_session',
-                      'com.vmware.content.library.item.download_session',
-                      'com.vmware.content.library.item.file',
-                      'com.vmware.content.library.item.storage',
-                      'com.vmware.content.library.item.downloadsession.file',
-                      'com.vmware.content.library.item.updatesession.file',
-                      'com.vmware.vcenter.iso.image']
-
-
-def is_service_auto_rest(service):
-    return service in auto_rest_services
-
-
 class HttpErrorMap:
     """
         Builds  error_map which maps vapi errors to http status codes.

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -7,11 +7,14 @@ import sys
 import six
 import re
 from six.moves import http_client
+
 TAG_SEPARATOR = '/'
 CAMELCASE_SEPARATOR_LIST = [".", "_"]
 
+
 def eprint(*args, **kwargs):
     print(*args, file=sys.stderr, **kwargs)
+
 
 def get_json(url, verify=True):
     try:
@@ -42,12 +45,12 @@ def load_description():
     """
     desc = {
         'content': 'VMware vSphere\u00ae Content Library empowers vSphere Admins to effectively manage VM templates, '
-        'vApps, ISO images and scripts with ease.',
+                   'vApps, ISO images and scripts with ease.',
         'spbm': 'SPBM',
         'vapi': 'vAPI is an extensible API Platform for modelling and delivering APIs/SDKs/CLIs.',
         'vcenter': 'VMware vCenter Server provides a centralized platform for managing your VMware vSphere environments',
         'appliance': 'The vCenter Server Appliance is a preconfigured Linux-based virtual machine'
-        ' optimized for running vCenter Server and associated services.'}
+                     ' optimized for running vCenter Server and associated services.'}
     return desc
 
 
@@ -55,7 +58,6 @@ def get_str_camel_case(string, *delimiters):
     delimiter_regex = '\\' + '|\\'.join(delimiters)
     words = [word[:1].upper() + word[1:] for word in re.split(delimiter_regex, string)]
     return ''.join(words)
-
 
 
 def is_filtered(metadata):
@@ -179,12 +181,14 @@ def build_path(
         path_obj['operationId'] = operation_id
     return path_obj
 
+
 def remove_curly_braces(string_name):
     if '{' in string_name:
-        string_name = string_name.replace('{','')
+        string_name = string_name.replace('{', '')
     if '}' in string_name:
-        string_name = string_name.replace('}','')
+        string_name = string_name.replace('}', '')
     return string_name
+
 
 def tags_from_service_name(service_name):
     """
@@ -293,6 +297,7 @@ def is_type_builtin(type_):
         return True
     return False
 
+
 def create_req_body_from_params_list(path_obj):
     # create request body section inside path object from parameter list
     parameters = path_obj['parameters']
@@ -300,45 +305,94 @@ def create_req_body_from_params_list(path_obj):
         index = -1
         for i in range(len(parameters)):
             if '$ref' in parameters[i] and parameters[i]['$ref'].startswith('#/components/requestBodies/'):
-                index  = i
+                index = i
                 break
         if index != -1:
-            path_obj['requestBody'] = {'$ref' : parameters[index]['$ref']}
+            path_obj['requestBody'] = {'$ref': parameters[index]['$ref']}
             del parameters[index]
-   
+
+
+auto_rest_services = ['com.vmware.vcenter.ovf.import_flag',
+                      'com.vmware.vcenter.ovf.export_flag',
+                      'com.vmware.vcenter.ovf.library_item',
+                      'com.vmware.cis.session',
+                      'com.vmware.vcenter.inventory.datastore',
+                      'com.vmware.vcenter.inventory.network',
+                      'com.vmware.cis.tagging.tag_association',
+                      'com.vmware.cis.tagging.category',
+                      'com.vmware.cis.tagging.tag',
+                      'com.vmware.vapi.metadata.metamodel.service.operation',
+                      'com.vmware.vapi.metadata.cli.command',
+                      'com.vmware.vapi.metadata.cli.namespace',
+                      'com.vmware.vapi.metadata.metamodel.package',
+                      'com.vmware.vapi.metadata.metamodel.service',
+                      'com.vmware.vapi.metadata.metamodel.structure',
+                      'com.vmware.vapi.metadata.metamodel.enumeration',
+                      'com.vmware.vapi.metadata.metamodel.component',
+                      'com.vmware.vapi.metadata.metamodel.resource',
+                      'com.vmware.vapi.metadata.metamodel.resource.model',
+                      'com.vmware.vapi.metadata.authentication.service.operation',
+                      'com.vmware.vapi.metadata.authentication.service',
+                      'com.vmware.vapi.metadata.authentication.component',
+                      'com.vmware.vapi.metadata.authentication.package',
+                      'com.vmware.vapi.metadata.privilege.component',
+                      'com.vmware.vapi.metadata.privilege.package',
+                      'com.vmware.vapi.metadata.privilege.service',
+                      'com.vmware.vapi.metadata.privilege.service.operation',
+                      'com.vmware.content.library',
+                      'com.vmware.content.local_library',
+                      'com.vmware.content.configuration',
+                      'com.vmware.content.subscribed_library',
+                      'com.vmware.content.type',
+                      'com.vmware.content.library.subscribed_item',
+                      'com.vmware.content.library.item',
+                      'com.vmware.content.library.subscriptions',
+                      'com.vmware.content.library.item.update_session',
+                      'com.vmware.content.library.item.download_session',
+                      'com.vmware.content.library.item.file',
+                      'com.vmware.content.library.item.storage',
+                      'com.vmware.content.library.item.downloadsession.file',
+                      'com.vmware.content.library.item.updatesession.file',
+                      'com.vmware.vcenter.iso.image']
+
+
+def is_service_auto_rest(service):
+    return service in auto_rest_services
+
 
 class HttpErrorMap:
     """
         Builds  error_map which maps vapi errors to http status codes.
     """
+
     def __init__(self, component_svc):
         self.component_svc = component_svc
         self.error_api_map = {}
         self.error_rest_map = {'com.vmware.vapi.std.errors.already_exists': http_client.BAD_REQUEST,
-                     'com.vmware.vapi.std.errors.already_in_desired_state': http_client.BAD_REQUEST,
-                     'com.vmware.vapi.std.errors.feature_in_use': http_client.BAD_REQUEST,
-                     'com.vmware.vapi.std.errors.internal_server_error': http_client.INTERNAL_SERVER_ERROR,
-                     'com.vmware.vapi.std.errors.invalid_argument': http_client.BAD_REQUEST,
-                     'com.vmware.vapi.std.errors.invalid_element_configuration': http_client.BAD_REQUEST,
-                     'com.vmware.vapi.std.errors.invalid_element_type': http_client.BAD_REQUEST,
-                     'com.vmware.vapi.std.errors.invalid_request': http_client.BAD_REQUEST,
-                     'com.vmware.vapi.std.errors.not_found': http_client.NOT_FOUND,
-                     'com.vmware.vapi.std.errors.operation_not_found': http_client.NOT_FOUND,
-                     'com.vmware.vapi.std.errors.not_allowed_in_current_state': http_client.BAD_REQUEST,
-                     'com.vmware.vapi.std.errors.resource_busy': http_client.BAD_REQUEST,
-                     'com.vmware.vapi.std.errors.resource_in_use': http_client.BAD_REQUEST,
-                     'com.vmware.vapi.std.errors.resource_inaccessible': http_client.BAD_REQUEST,
-                     'com.vmware.vapi.std.errors.service_unavailable': http_client.SERVICE_UNAVAILABLE,
-                     'com.vmware.vapi.std.errors.timed_out': http_client.GATEWAY_TIMEOUT,
-                     'com.vmware.vapi.std.errors.unable_to_allocate_resource': http_client.BAD_REQUEST,
-                     'com.vmware.vapi.std.errors.unauthenticated': http_client.UNAUTHORIZED,
-                     'com.vmware.vapi.std.errors.unauthorized': http_client.FORBIDDEN,
-                     'com.vmware.vapi.std.errors.unexpected_input': http_client.BAD_REQUEST,
-                     'com.vmware.vapi.std.errors.unsupported': http_client.BAD_REQUEST,
-                     'com.vmware.vapi.std.errors.error': http_client.BAD_REQUEST,
-                     'com.vmware.vapi.std.errors.concurrent_change': http_client.BAD_REQUEST,
-                     'com.vmware.vapi.std.errors.canceled': http_client.BAD_REQUEST,
-                     'com.vmware.vapi.std.errors.unverified_peer': http_client.BAD_REQUEST}
+                               'com.vmware.vapi.std.errors.already_in_desired_state': http_client.BAD_REQUEST,
+                               'com.vmware.vapi.std.errors.feature_in_use': http_client.BAD_REQUEST,
+                               'com.vmware.vapi.std.errors.internal_server_error': http_client.INTERNAL_SERVER_ERROR,
+                               'com.vmware.vapi.std.errors.invalid_argument': http_client.BAD_REQUEST,
+                               'com.vmware.vapi.std.errors.invalid_element_configuration': http_client.BAD_REQUEST,
+                               'com.vmware.vapi.std.errors.invalid_element_type': http_client.BAD_REQUEST,
+                               'com.vmware.vapi.std.errors.invalid_request': http_client.BAD_REQUEST,
+                               'com.vmware.vapi.std.errors.not_found': http_client.NOT_FOUND,
+                               'com.vmware.vapi.std.errors.operation_not_found': http_client.NOT_FOUND,
+                               'com.vmware.vapi.std.errors.not_allowed_in_current_state': http_client.BAD_REQUEST,
+                               'com.vmware.vapi.std.errors.resource_busy': http_client.BAD_REQUEST,
+                               'com.vmware.vapi.std.errors.resource_in_use': http_client.BAD_REQUEST,
+                               'com.vmware.vapi.std.errors.resource_inaccessible': http_client.BAD_REQUEST,
+                               'com.vmware.vapi.std.errors.service_unavailable': http_client.SERVICE_UNAVAILABLE,
+                               'com.vmware.vapi.std.errors.timed_out': http_client.GATEWAY_TIMEOUT,
+                               'com.vmware.vapi.std.errors.unable_to_allocate_resource': http_client.BAD_REQUEST,
+                               'com.vmware.vapi.std.errors.unauthenticated': http_client.UNAUTHORIZED,
+                               'com.vmware.vapi.std.errors.unauthorized': http_client.FORBIDDEN,
+                               'com.vmware.vapi.std.errors.unexpected_input': http_client.BAD_REQUEST,
+                               'com.vmware.vapi.std.errors.unsupported': http_client.BAD_REQUEST,
+                               'com.vmware.vapi.std.errors.error': http_client.BAD_REQUEST,
+                               'com.vmware.vapi.std.errors.concurrent_change': http_client.BAD_REQUEST,
+                               'com.vmware.vapi.std.errors.canceled': http_client.BAD_REQUEST,
+                               'com.vmware.vapi.std.errors.unverified_peer': http_client.BAD_REQUEST}
 
         structures = self.component_svc.get('com.vmware.vapi').info.packages['com.vmware.vapi.std.errors'].structures
         for structure in structures:

--- a/test_lib.py
+++ b/test_lib.py
@@ -19,85 +19,91 @@ class TestInputs(unittest.TestCase):
         test_args = ['vmsgen', '-vc', 'v_url']
         ssl_verify_expected = True
         with mock.patch('sys.argv', test_args):
-            _, _, _, ssl_verify_actual, _, _, _, _, _, _, = connection.get_input_params()
+            _, _, _, ssl_verify_actual, _, _, _, _, _, _, _, = connection.get_input_params()
         self.assertEqual(ssl_verify_expected, ssl_verify_actual)
 
         # case 1.2: SSL is insecure
         test_args = ['vmsgen', '-vc', 'v_url', '-k']
         ssl_verify_expected = False
         with mock.patch('sys.argv', test_args):
-            _, _, _, ssl_verify_actual, _, _, _, _, _, _, = connection.get_input_params()
+            _, _, _, ssl_verify_actual, _, _, _, _, _, _, _, = connection.get_input_params()
         self.assertEqual(ssl_verify_expected, ssl_verify_actual)
 
         # case 2.1: tag separator option (default)
         test_args = ['vmsgen', '-vc', 'v_url', '-k']
         tag_separator_expected = '/'
         with mock.patch('sys.argv', test_args):
-            _, _, _, _, _, _, _, _, tag_separator_actual, _, = connection.get_input_params()
+            _, _, _, _, _, _, _, _, tag_separator_actual, _, _, = connection.get_input_params()
         self.assertEqual(tag_separator_expected, tag_separator_actual)
 
         # case 2.2: tag separator option
         expected = '_'
         test_args = ['vmsgen', '-vc', 'v_url', '-s', expected]
         with mock.patch('sys.argv', test_args):
-            _, _, _, _, _, _, _, _, tag_separator_actual, _, = connection.get_input_params()
+            _, _, _, _, _, _, _, _, tag_separator_actual, _, _, = connection.get_input_params()
         self.assertEqual(expected, tag_separator_actual)
 
         # case 3.1: operation id option is FALSE
         test_args = ['vmsgen', '-vc', 'v_url', '-k']
         generate_op_id_expected = False
         with mock.patch('sys.argv', test_args):
-            _, _, _, _, _, _, _, generate_op_id_actual, _, _, = connection.get_input_params()
+            _, _, _, _, _, _, _, generate_op_id_actual, _, _, _, = connection.get_input_params()
         self.assertEqual(generate_op_id_expected, generate_op_id_actual)
 
         # case 3.1: operation id option is TRUE
         test_args = ['vmsgen', '-vc', 'v_url', '-k', '-uo']
         generate_op_id_expected = True
         with mock.patch('sys.argv', test_args):
-            _, _, _, _, _, _, _, generate_op_id_actual, _, _, = connection.get_input_params()
+            _, _, _, _, _, _, _, generate_op_id_actual, _, _, _, = connection.get_input_params()
         self.assertEqual(generate_op_id_expected, generate_op_id_actual)
 
         # case 4.1: generate metamodel option is FALSE
         test_args = ['vmsgen', '-vc', 'v_url', '-k']
         generate_metamodel_expected = False
         with mock.patch('sys.argv', test_args):
-            _, _, _, _, _, generate_metamodel_actual, _, _, _, _, = connection.get_input_params()
+            _, _, _, _, _, generate_metamodel_actual, _, _, _, _, _, = connection.get_input_params()
         self.assertEqual(generate_metamodel_expected, generate_metamodel_actual)
 
         # case 4.1: generate metamodel option is TRUE
         test_args = ['vmsgen', '-vc', 'v_url', '-k', '-c']
         generate_metamodel_expected = True
         with mock.patch('sys.argv', test_args):
-            _, _, _, _, _, generate_metamodel_actual, _, _, _, _, = connection.get_input_params()
+            _, _, _, _, _, generate_metamodel_actual, _, _, _, _, _, = connection.get_input_params()
         self.assertEqual(generate_metamodel_expected, generate_metamodel_actual)
         
         # case 5.1: swagger specification is default i.e openAPI 3.0
         test_args = ['vmsgen', '-vc', 'v_url', '-k']
         swagger_specification_expected = '3'
         with mock.patch('sys.argv', test_args):
-            _, _, _, _, _, _, swagger_specification_actual, _, _, _, = connection.get_input_params()
+            _, _, _, _, _, _, swagger_specification_actual, _, _, _, _, = connection.get_input_params()
         self.assertEqual(swagger_specification_expected, swagger_specification_actual)
 
         # case 5.2: swagger specification is swagger 2.0
         test_args = ['vmsgen', '-vc', 'v_url', '-k', '-oas' , '2']
         swagger_specification_expected = '2'
         with mock.patch('sys.argv', test_args):
-            _, _, _, _, _, _, swagger_specification_actual, _, _, _, = connection.get_input_params()
+            _, _, _, _, _, _, swagger_specification_actual, _, _, _, _, = connection.get_input_params()
         self.assertEqual(swagger_specification_expected, swagger_specification_actual)
 
         # case 6.1: deprecated option is TRUE
         test_args = ['vmsgen', '-vc', 'v_url', '-k', '--deprecate-slash-rest']
         deprecated_expected = True
         with mock.patch('sys.argv', test_args):
-            _, _, _, _, _, _, _, _, _, deprecated_actual = connection.get_input_params()
+            _, _, _, _, _, _, _, _, _, deprecated_actual, _,= connection.get_input_params()
         self.assertEqual(deprecated_expected, deprecated_actual)
 
         # case 6.1: deprecated option is FALSE
         test_args = ['vmsgen', '-vc', 'v_url', '-k']
         deprecated_expected = False
         with mock.patch('sys.argv', test_args):
-            _, _, _, _, _, _, _, _, _, deprecated_actual = connection.get_input_params()
+            _, _, _, _, _, _, _, _, _, deprecated_actual, _, = connection.get_input_params()
         self.assertEqual(deprecated_expected, deprecated_actual)
+
+        # case 7.1: fetch security
+        test_args = ['vmsgen', '-vc',  'v_url', '-k', '-fam']
+        with mock.patch('sys.argv', test_args):
+            _, _, _, _, _, _, _, _, _, _, fetch_security = connection.get_input_params()
+        self.assertEqual(True, fetch_security)
 
 
 class TestDictionaryProcessing(unittest.TestCase):
@@ -263,15 +269,17 @@ class TestDictionaryProcessing(unittest.TestCase):
         path_list_expected = ['mock_string_value']
         replacement_dict_expected = {service: {"mock-key-1": ("put", "mock_string_value")}}
         replacement_dict_actual = {}
-        service_type_actual, path_list_actual = dict_processing.get_paths_inside_metamodel(service, service_dict, True, replacement_dict_actual)
+        service_type_actual, path_list_actual = dict_processing.get_paths_inside_metamodel(service,
+                                                                                           service_dict,
+                                                                                           True,
+                                                                                           replacement_dict_actual)
         self.assertEqual(ServiceType.SLASH_REST_AND_API, service_type_actual)
         self.assertEqual(path_list_expected, path_list_actual)
         self.assertEqual(replacement_dict_expected, replacement_dict_actual)
 
         # case 3.2: https methods ('put', 'post', 'patch', 'get', 'delete') in metadata.keys with deprecated applied
-        # and apparent in navigation service
+        # and apparent in Auto Rest
         rest_navigation_handler = RestNavigationHandler("")
-        rest_navigation_handler.get_service_operations = mock.MagicMock(return_value={})
         element_value_mock = mock.Mock()
         element_value_mock.string_value = 'mock_string_value'
         element_info_mock = mock.Mock()
@@ -284,14 +292,14 @@ class TestDictionaryProcessing(unittest.TestCase):
         service_info_mock.operations = {
             'mock-key-1': operation_info_mock
         }
-        service = 'com.vmware.package-mock-1.mock.mock'
+        service = 'com.vmware.vcenter.iso.image'
         service_dict = {
-            'com.vmware.package-mock-1.mock.mock': service_info_mock
+            service: service_info_mock
         }
         '''
         Structure of key-value pair in service_dict
         service_dict = {
-            'com.vmware.package-mock-1.mock.mock':  
+            'com.vmware.vcenter.iso.image':  
                 ServiceInfo(
                 operations = {
                     'mock-key-1': OperationInfo(metadata = {
@@ -308,9 +316,7 @@ class TestDictionaryProcessing(unittest.TestCase):
         service_type_actual, path_list_actual = dict_processing.get_paths_inside_metamodel(service,
                                                                                            service_dict,
                                                                                            True,
-                                                                                           replacement_dict_actual,
-                                                                                           "sample_service_url",
-                                                                                           rest_navigation_handler)
+                                                                                           replacement_dict_actual)
         self.assertEqual(ServiceType.SLASH_REST_AND_API, service_type_actual)
         self.assertEqual(path_list_expected, path_list_actual)
         self.assertEqual(replacement_dict_expected, replacement_dict_actual)
@@ -321,7 +327,6 @@ class TestDictionaryProcessing(unittest.TestCase):
         service_urls_map = {'https://vcip/rest/com/vmware/package/mock' : 'com.vmware.package.mock'}
         rest_navigation_url = 'https://vcip/rest'
         rest_navigation_handler = RestNavigationHandler(rest_navigation_url)
-        rest_navigation_handler.get_service_operations = mock.MagicMock(return_value=None)
         element_value_mock = mock.Mock()
         element_value_mock.string_value = '/package/mock'
         element_info_mock = mock.Mock()
@@ -357,9 +362,13 @@ class TestDictionaryProcessing(unittest.TestCase):
         self.assertEqual(package_dict_api_expected, package_dict_api_actual)
         self.assertEqual({}, package_dict_actual)
 
-        # case 2: /api operation and /rest equivalent (RestNavigation)
-        # Rest navigation returns not None
-        rest_navigation_handler.get_service_operations = mock.MagicMock(return_value={})
+        # case 2: /api operation and /rest equivalent
+        # Service is apparent in auto rest
+        service_urls_map = {'https://vcip/rest/com/vmware/package/mock': 'com.vmware.vcenter.iso.image'}
+        service_dict = {
+            'com.vmware.vcenter.iso.image': service_info_mock
+        }
+
         # case 2.1: --deprecate-slash-rest off
         package_dict_api_actual, \
         package_dict_actual, _, _, = dict_processing.add_service_urls_using_metamodel(service_urls_map,
@@ -384,6 +393,9 @@ class TestDictionaryProcessing(unittest.TestCase):
 
         # case 3: /rest operation only
         service_urls_map = {'https://vcip/rest/vmware/com/package/mock': 'com.vmware.package.mock'}
+        service_dict = {
+            'com.vmware.package.mock': service_info_mock
+        }
         element_value_mock.string_value = 'mock_string_value'
         operation_info_mock.metadata = {
             'mock_element_key': element_info_mock

--- a/test_lib.py
+++ b/test_lib.py
@@ -386,7 +386,15 @@ class TestDictionaryProcessing(unittest.TestCase):
         self.assertEqual({}, package_dict_actual)
 
         # case 2: /api operation and /rest equivalent
-        # Service is apparent in auto rest
+        # Service is not apparent in auto_rest_services
+        rest_navigation_handler.get_service_operations = mock.MagicMock(return_value={})
+        package_dict_api_actual, \
+        package_dict_actual, _, _, = dict_processing.add_service_urls_using_metamodel(service_urls_map,
+                                                                                      service_dict,
+                                                                                      rest_navigation_handler,
+                                                                                      auto_rest_services)
+
+        # Service is apparent in auto_rest_services
         service_urls_map = {'https://vcip/rest/com/vmware/package/mock': 'com.vmware.vcenter.iso.image'}
         service_dict = {
             'com.vmware.vcenter.iso.image': service_info_mock

--- a/test_lib.py
+++ b/test_lib.py
@@ -19,91 +19,99 @@ class TestInputs(unittest.TestCase):
         test_args = ['vmsgen', '-vc', 'v_url']
         ssl_verify_expected = True
         with mock.patch('sys.argv', test_args):
-            _, _, _, ssl_verify_actual, _, _, _, _, _, _, _, = connection.get_input_params()
+            _, _, _, ssl_verify_actual, _, _, _, _, _, _, _, _, = connection.get_input_params()
         self.assertEqual(ssl_verify_expected, ssl_verify_actual)
 
         # case 1.2: SSL is insecure
         test_args = ['vmsgen', '-vc', 'v_url', '-k']
         ssl_verify_expected = False
         with mock.patch('sys.argv', test_args):
-            _, _, _, ssl_verify_actual, _, _, _, _, _, _, _, = connection.get_input_params()
+            _, _, _, ssl_verify_actual, _, _, _, _, _, _, _, _, = connection.get_input_params()
         self.assertEqual(ssl_verify_expected, ssl_verify_actual)
 
         # case 2.1: tag separator option (default)
         test_args = ['vmsgen', '-vc', 'v_url', '-k']
         tag_separator_expected = '/'
         with mock.patch('sys.argv', test_args):
-            _, _, _, _, _, _, _, _, tag_separator_actual, _, _, = connection.get_input_params()
+            _, _, _, _, _, _, _, _, tag_separator_actual, _, _, _, = connection.get_input_params()
         self.assertEqual(tag_separator_expected, tag_separator_actual)
 
         # case 2.2: tag separator option
         expected = '_'
         test_args = ['vmsgen', '-vc', 'v_url', '-s', expected]
         with mock.patch('sys.argv', test_args):
-            _, _, _, _, _, _, _, _, tag_separator_actual, _, _, = connection.get_input_params()
+            _, _, _, _, _, _, _, _, tag_separator_actual, _, _, _, = connection.get_input_params()
         self.assertEqual(expected, tag_separator_actual)
 
         # case 3.1: operation id option is FALSE
         test_args = ['vmsgen', '-vc', 'v_url', '-k']
         generate_op_id_expected = False
         with mock.patch('sys.argv', test_args):
-            _, _, _, _, _, _, _, generate_op_id_actual, _, _, _, = connection.get_input_params()
+            _, _, _, _, _, _, _, generate_op_id_actual, _, _, _, _, = connection.get_input_params()
         self.assertEqual(generate_op_id_expected, generate_op_id_actual)
 
         # case 3.1: operation id option is TRUE
         test_args = ['vmsgen', '-vc', 'v_url', '-k', '-uo']
         generate_op_id_expected = True
         with mock.patch('sys.argv', test_args):
-            _, _, _, _, _, _, _, generate_op_id_actual, _, _, _, = connection.get_input_params()
+            _, _, _, _, _, _, _, generate_op_id_actual, _, _, _, _, = connection.get_input_params()
         self.assertEqual(generate_op_id_expected, generate_op_id_actual)
 
         # case 4.1: generate metamodel option is FALSE
         test_args = ['vmsgen', '-vc', 'v_url', '-k']
         generate_metamodel_expected = False
         with mock.patch('sys.argv', test_args):
-            _, _, _, _, _, generate_metamodel_actual, _, _, _, _, _, = connection.get_input_params()
+            _, _, _, _, _, generate_metamodel_actual, _, _, _, _, _, _, = connection.get_input_params()
         self.assertEqual(generate_metamodel_expected, generate_metamodel_actual)
 
         # case 4.1: generate metamodel option is TRUE
         test_args = ['vmsgen', '-vc', 'v_url', '-k', '-c']
         generate_metamodel_expected = True
         with mock.patch('sys.argv', test_args):
-            _, _, _, _, _, generate_metamodel_actual, _, _, _, _, _, = connection.get_input_params()
+            _, _, _, _, _, generate_metamodel_actual, _, _, _, _, _, _, = connection.get_input_params()
         self.assertEqual(generate_metamodel_expected, generate_metamodel_actual)
         
         # case 5.1: swagger specification is default i.e openAPI 3.0
         test_args = ['vmsgen', '-vc', 'v_url', '-k']
         swagger_specification_expected = '3'
         with mock.patch('sys.argv', test_args):
-            _, _, _, _, _, _, swagger_specification_actual, _, _, _, _, = connection.get_input_params()
+            _, _, _, _, _, _, swagger_specification_actual, _, _, _, _, _, = connection.get_input_params()
         self.assertEqual(swagger_specification_expected, swagger_specification_actual)
 
         # case 5.2: swagger specification is swagger 2.0
         test_args = ['vmsgen', '-vc', 'v_url', '-k', '-oas' , '2']
         swagger_specification_expected = '2'
         with mock.patch('sys.argv', test_args):
-            _, _, _, _, _, _, swagger_specification_actual, _, _, _, _, = connection.get_input_params()
+            _, _, _, _, _, _, swagger_specification_actual, _, _, _, _, _, = connection.get_input_params()
         self.assertEqual(swagger_specification_expected, swagger_specification_actual)
 
         # case 6.1: deprecated option is TRUE
         test_args = ['vmsgen', '-vc', 'v_url', '-k', '--deprecate-slash-rest']
         deprecated_expected = True
         with mock.patch('sys.argv', test_args):
-            _, _, _, _, _, _, _, _, _, deprecated_actual, _,= connection.get_input_params()
+            _, _, _, _, _, _, _, _, _, deprecated_actual, _, _, = connection.get_input_params()
         self.assertEqual(deprecated_expected, deprecated_actual)
 
-        # case 6.1: deprecated option is FALSE
+        # case 6.2: deprecated option is FALSE
         test_args = ['vmsgen', '-vc', 'v_url', '-k']
         deprecated_expected = False
         with mock.patch('sys.argv', test_args):
-            _, _, _, _, _, _, _, _, _, deprecated_actual, _, = connection.get_input_params()
+            _, _, _, _, _, _, _, _, _, deprecated_actual, _, _, = connection.get_input_params()
         self.assertEqual(deprecated_expected, deprecated_actual)
 
-        # case 7.1: fetch security
+        # case 7: fetch security
         test_args = ['vmsgen', '-vc',  'v_url', '-k', '-fam']
         with mock.patch('sys.argv', test_args):
-            _, _, _, _, _, _, _, _, _, _, fetch_security = connection.get_input_params()
+            _, _, _, _, _, _, _, _, _, _, fetch_security, _, = connection.get_input_params()
         self.assertEqual(True, fetch_security)
+
+        # case 8: auto rest services
+        test_args = ['vmsgen', '-vc',  'v_url', '-k', '-ars', 'com.vmware.vcenter.ovf.import_flag',
+                     'com.vmware.content.library.item.storage']
+        with mock.patch('sys.argv', test_args):
+            _, _, _, _, _, _, _, _, _, _, _, auto_rest_services = connection.get_input_params()
+        self.assertEqual(['com.vmware.vcenter.ovf.import_flag', 'com.vmware.content.library.item.storage'],
+                         auto_rest_services)
 
 
 class TestDictionaryProcessing(unittest.TestCase):
@@ -130,6 +138,8 @@ class TestDictionaryProcessing(unittest.TestCase):
         self.assertEqual(service_url_expected, service_url_actual)
     
     def test_get_paths_inside_metamodel(self):
+        auto_rest_services = ['com.vmware.vcenter.iso.image']
+
         #case 1: https methods ('put', 'post', 'patch', 'get', 'delete') not in metadata.keys
         operation_info_mock = mock.Mock()
         operation_info_mock.metadata = { 
@@ -156,7 +166,9 @@ class TestDictionaryProcessing(unittest.TestCase):
             }
         '''
         path_list_expected = []
-        service_type_actual, path_list_actual = dict_processing.get_paths_inside_metamodel(service, service_dict)
+        service_type_actual, path_list_actual = dict_processing.get_paths_inside_metamodel(service,
+                                                                                           service_dict,
+                                                                                           auto_rest_services)
         self.assertEqual(ServiceType.SLASH_REST, service_type_actual)
         self.assertEqual(path_list_expected, path_list_actual)
 
@@ -192,7 +204,9 @@ class TestDictionaryProcessing(unittest.TestCase):
             }
         '''
         path_list_expected = ['mock_string_value']
-        service_type_actual, path_list_actual = dict_processing.get_paths_inside_metamodel(service, service_dict)
+        service_type_actual, path_list_actual = dict_processing.get_paths_inside_metamodel(service,
+                                                                                           service_dict,
+                                                                                           auto_rest_services)
         self.assertEqual(ServiceType.SLASH_API, service_type_actual)
         self.assertEqual(path_list_expected, path_list_actual)
 
@@ -228,7 +242,10 @@ class TestDictionaryProcessing(unittest.TestCase):
             }
         '''
         path_list_expected = ['mock_string_value']
-        service_type_actual, path_list_actual = dict_processing.get_paths_inside_metamodel(service, service_dict, True)
+        service_type_actual, path_list_actual = dict_processing.get_paths_inside_metamodel(service,
+                                                                                           service_dict,
+                                                                                           auto_rest_services,
+                                                                                           True)
         self.assertEqual(ServiceType.SLASH_API, service_type_actual)
         self.assertEqual(path_list_expected, path_list_actual)
 
@@ -271,6 +288,7 @@ class TestDictionaryProcessing(unittest.TestCase):
         replacement_dict_actual = {}
         service_type_actual, path_list_actual = dict_processing.get_paths_inside_metamodel(service,
                                                                                            service_dict,
+                                                                                           auto_rest_services,
                                                                                            True,
                                                                                            replacement_dict_actual)
         self.assertEqual(ServiceType.SLASH_REST_AND_API, service_type_actual)
@@ -315,6 +333,7 @@ class TestDictionaryProcessing(unittest.TestCase):
         replacement_dict_actual = {}
         service_type_actual, path_list_actual = dict_processing.get_paths_inside_metamodel(service,
                                                                                            service_dict,
+                                                                                           auto_rest_services,
                                                                                            True,
                                                                                            replacement_dict_actual)
         self.assertEqual(ServiceType.SLASH_REST_AND_API, service_type_actual)
@@ -323,6 +342,8 @@ class TestDictionaryProcessing(unittest.TestCase):
 
 
     def test_add_service_urls_using_metamodel(self):
+        auto_rest_services = ['com.vmware.vcenter.iso.image']
+
         # case 1: /api operation only
         service_urls_map = {'https://vcip/rest/com/vmware/package/mock' : 'com.vmware.package.mock'}
         rest_navigation_url = 'https://vcip/rest'
@@ -349,7 +370,8 @@ class TestDictionaryProcessing(unittest.TestCase):
         package_dict_api_actual, \
         package_dict_actual, _, _, = dict_processing.add_service_urls_using_metamodel(service_urls_map,
                                                                                       service_dict,
-                                                                                      rest_navigation_handler)
+                                                                                      rest_navigation_handler,
+                                                                                      auto_rest_services)
         self.assertEqual(package_dict_api_expected, package_dict_api_actual)
         self.assertEqual({}, package_dict_actual)
 
@@ -358,6 +380,7 @@ class TestDictionaryProcessing(unittest.TestCase):
         package_dict_actual, _, _, = dict_processing.add_service_urls_using_metamodel(service_urls_map,
                                                                                       service_dict,
                                                                                       rest_navigation_handler,
+                                                                                      auto_rest_services,
                                                                                       True)
         self.assertEqual(package_dict_api_expected, package_dict_api_actual)
         self.assertEqual({}, package_dict_actual)
@@ -373,7 +396,8 @@ class TestDictionaryProcessing(unittest.TestCase):
         package_dict_api_actual, \
         package_dict_actual, _, _, = dict_processing.add_service_urls_using_metamodel(service_urls_map,
                                                                                       service_dict,
-                                                                                      rest_navigation_handler)
+                                                                                      rest_navigation_handler,
+                                                                                      auto_rest_services)
         package_dict_expected = {'package': ['/com/vmware/package/mock']}
         self.assertEqual({}, package_dict_api_actual)
         self.assertEqual(package_dict_expected, package_dict_actual)
@@ -384,6 +408,7 @@ class TestDictionaryProcessing(unittest.TestCase):
         package_dict_deprecated_actual, _, = dict_processing.add_service_urls_using_metamodel(service_urls_map,
                                                                                               service_dict,
                                                                                               rest_navigation_handler,
+                                                                                              auto_rest_services,
                                                                                               True)
         package_dict_expected = {'package': ['/com/vmware/package/mock']}
         package_dict_api_expected = {'package': ['/package/mock']}
@@ -404,12 +429,14 @@ class TestDictionaryProcessing(unittest.TestCase):
         package_dict_expected = {'package': ['/vmware/com/package/mock']}
         _, package_dict_actual, _, _, = dict_processing.add_service_urls_using_metamodel(service_urls_map,
                                                                                          service_dict,
-                                                                                         rest_navigation_handler)
+                                                                                         rest_navigation_handler,
+                                                                                         auto_rest_services)
         # case 3.2: --deprecate-slash-rest on
         self.assertEqual(package_dict_expected, package_dict_actual)
         _, package_dict_actual, _, _, = dict_processing.add_service_urls_using_metamodel(service_urls_map,
                                                                                          service_dict,
                                                                                          rest_navigation_handler,
+                                                                                         auto_rest_services,
                                                                                          True)
         self.assertEqual(package_dict_expected, package_dict_actual)
 
@@ -426,7 +453,8 @@ class TestDictionaryProcessing(unittest.TestCase):
         package_dict_actual, \
         package_dict_deprecated_actual, _, = dict_processing.add_service_urls_using_metamodel(service_urls_map,
                                                                                               service_dict,
-                                                                                              rest_navigation_handler)
+                                                                                              rest_navigation_handler,
+                                                                                              auto_rest_services)
 
         self.assertEqual({}, package_dict_deprecated_actual)
         self.assertEqual({}, package_dict_api_actual)
@@ -440,6 +468,7 @@ class TestDictionaryProcessing(unittest.TestCase):
         package_dict_deprecated_actual, _, = dict_processing.add_service_urls_using_metamodel(service_urls_map,
                                                                                               service_dict,
                                                                                               rest_navigation_handler,
+                                                                                              auto_rest_services,
                                                                                               True)
 
         self.assertEqual(package_dict_deprecated_expected, package_dict_deprecated_actual)
@@ -458,7 +487,8 @@ class TestDictionaryProcessing(unittest.TestCase):
         package_dict_actual, \
         package_dict_deprecated_actual, _, = dict_processing.add_service_urls_using_metamodel(service_urls_map,
                                                                                               service_dict,
-                                                                                              rest_navigation_handler)
+                                                                                              rest_navigation_handler,
+                                                                                              auto_rest_services)
         package_dict_expected = {'package': ['/vmware/com/package/mock']}
         self.assertEqual(package_dict_expected, package_dict_actual)
 
@@ -470,6 +500,7 @@ class TestDictionaryProcessing(unittest.TestCase):
         package_dict_deprecated_actual, _, = dict_processing.add_service_urls_using_metamodel(service_urls_map,
                                                                                               service_dict,
                                                                                               rest_navigation_handler,
+                                                                                              auto_rest_services,
                                                                                               True)
         self.assertEqual(package_dict_deprecated_expected, package_dict_deprecated_actual)
         self.assertEqual(package_dict_api_expected, package_dict_api_actual)

--- a/test_utils.py
+++ b/test_utils.py
@@ -71,13 +71,5 @@ class TestUtils(unittest.TestCase):
         expected = "ComVmwarePackageMock1"
         self.assertEqual(expected, utils.get_str_camel_case(string, *utils.CAMELCASE_SEPARATOR_LIST))
 
-
-    def test_auto_rest_service(self):
-        service = "my.test.service"
-        self.assertEqual(False, utils.is_service_auto_rest(service))
-
-        service = "com.vmware.vcenter.iso.image"
-        self.assertEqual(True, utils.is_service_auto_rest(service))
-
 if __name__ == '__main__':
     unittest.main()

--- a/test_utils.py
+++ b/test_utils.py
@@ -71,5 +71,13 @@ class TestUtils(unittest.TestCase):
         expected = "ComVmwarePackageMock1"
         self.assertEqual(expected, utils.get_str_camel_case(string, *utils.CAMELCASE_SEPARATOR_LIST))
 
+
+    def test_auto_rest_service(self):
+        service = "my.test.service"
+        self.assertEqual(False, utils.is_service_auto_rest(service))
+
+        service = "com.vmware.vcenter.iso.image"
+        self.assertEqual(True, utils.is_service_auto_rest(service))
+
 if __name__ == '__main__':
     unittest.main()

--- a/vmsgen.py
+++ b/vmsgen.py
@@ -37,7 +37,6 @@ TAG_SEPARATOR = '/'
 SPECIFICATION = '3'
 DEPRECATE_REST = False
 
-
 def main():
     # Get user input.
     metadata_api_url, \
@@ -50,7 +49,8 @@ def main():
     GENERATE_UNIQUE_OP_IDS, \
     TAG_SEPARATOR, \
     DEPRECATE_REST,\
-    fetch_auth_metadata = connection.get_input_params()
+    fetch_auth_metadata,\
+    auto_rest_services = connection.get_input_params()
     # Maps enumeration id to enumeration info
     enumeration_dict = {}
     # Maps structure_id to structure_info
@@ -99,7 +99,7 @@ def main():
     # deprecated with /api
     # replacement_dict contains information about the deprecated /rest to /api mappings
     package_dict_api, package_dict, package_dict_deprecated, replacement_dict = dict_processing.add_service_urls_using_metamodel(
-        service_urls_map, service_dict, rest_navigation_handler, DEPRECATE_REST)
+        service_urls_map, service_dict, rest_navigation_handler, auto_rest_services, DEPRECATE_REST)
 
 
     utils.combine_dicts_with_list_values(package_dict, package_dict_deprecated)

--- a/vmsgen.py
+++ b/vmsgen.py
@@ -49,7 +49,8 @@ def main():
     SPECIFICATION, \
     GENERATE_UNIQUE_OP_IDS, \
     TAG_SEPARATOR, \
-    DEPRECATE_REST = connection.get_input_params()
+    DEPRECATE_REST,\
+    fetch_auth_metadata = connection.get_input_params()
     # Maps enumeration id to enumeration info
     enumeration_dict = {}
     # Maps structure_id to structure_info
@@ -73,10 +74,12 @@ def main():
     print('Connected to ' + metadata_api_url)
     component_svc = connection.get_component_service(connector)
 
-    # Fetch authentication metadata and initialize the authentication data navigator
-    auth_component_svc = connection.get_authentication_component_service(connector)
-    auth_dict = authentication_metadata_processing.get_authentication_dict(auth_component_svc)
-    auth_navigator = AuthenticationDictNavigator(auth_dict)
+    auth_navigator = None
+    if fetch_auth_metadata:
+        # Fetch authentication metadata and initialize the authentication data navigator
+        auth_component_svc = connection.get_authentication_component_service(connector)
+        auth_dict = authentication_metadata_processing.get_authentication_dict(auth_component_svc)
+        auth_navigator = AuthenticationDictNavigator(auth_dict)
 
     dict_processing.populate_dicts(
         component_svc,
@@ -97,6 +100,7 @@ def main():
     # replacement_dict contains information about the deprecated /rest to /api mappings
     package_dict_api, package_dict, package_dict_deprecated, replacement_dict = dict_processing.add_service_urls_using_metamodel(
         service_urls_map, service_dict, rest_navigation_handler, DEPRECATE_REST)
+
 
     utils.combine_dicts_with_list_values(package_dict, package_dict_deprecated)
     if DEPRECATE_REST:


### PR DESCRIPTION
The current commit optimizes the generation time by introducing a
static map, holding all Auto Rest services, hence, rest_navigation
calls are no longer required. Also, a switch for the security
definitions is introduced.

Execution time is improved with around 180-210 seconds, 
depending on the security switch.

Signed-off-by: Anton Obretenov <obretenova@vmware.com>