### PR TITLE
Fix incorrect deprecation replacement path

### DIFF
--- a/lib/dictionary_processing.py
+++ b/lib/dictionary_processing.py
@@ -209,7 +209,12 @@ def get_paths_inside_metamodel(service,
                     is_rest_navigation_checked = True
 
                 if has_rest_counterpart:
-                    add_replacement_path(service, operation_id, request.lower(), path, replacement_dict)
+                    url = path
+                    if 'params' in service_dict[service].operations[operation_id].metadata[request].elements:
+                        element_value = service_dict[service].operations[operation_id].metadata[request].elements['params']
+                        params = "&".join(element_value.list_value)
+                        url = path + '?' + params
+                    add_replacement_path(service, operation_id, request.lower(), url, replacement_dict)
 
                 if not has_rest_counterpart or deprecate_rest or blacklist_utils.is_blacklisted_for_rest(service):
                     path_list.add(path)

--- a/lib/establish_connection.py
+++ b/lib/establish_connection.py
@@ -91,7 +91,7 @@ def get_input_params():
         dest='fetch_auth_metadata',
         help='retrieves authentication information from the authentication metadata service')
     parser.add_argument(
-        '-ars'
+        '-ars',
         '--auto-rest-services',
         nargs='+',
         default=[],

--- a/lib/rest_endpoint/rest_deprecation_handler.py
+++ b/lib/rest_endpoint/rest_deprecation_handler.py
@@ -24,7 +24,7 @@ class RestDeprecationHandler:
                 # get concrete path and format accordingly
                 replacement_path = method_path_tuple[1]
                 replacement_path = replacement_path.replace("/", "~1")
-                replacement_path = api_file_name + "#/paths/" + replacement_path + "/" + method_path_tuple[0]
+                replacement_path = api_file_name + "#/paths/~1api" + replacement_path + "/" + method_path_tuple[0]
 
         path_obj["x-vmw-deprecated"] = {"replacement": replacement_path}
 

--- a/test_lib.py
+++ b/test_lib.py
@@ -300,9 +300,12 @@ class TestDictionaryProcessing(unittest.TestCase):
         rest_navigation_handler = RestNavigationHandler("")
         element_value_mock = mock.Mock()
         element_value_mock.string_value = 'mock_string_value'
+        element_params_value_mock = mock.Mock()
+        element_params_value_mock.list_value = ['action=filter', 'action=cancel']
         element_info_mock = mock.Mock()
         element_info_mock.elements = {
-            'path': element_value_mock
+            'path': element_value_mock,
+            'params': element_params_value_mock
         }
         operation_info_mock.metadata = {
             'put': element_info_mock,
@@ -322,14 +325,17 @@ class TestDictionaryProcessing(unittest.TestCase):
                 operations = {
                     'mock-key-1': OperationInfo(metadata = {
                                         'put' : ElementInfo(elemets = {
-                                            'path' : ElementValue(string_value = 'mock_string_value')
+                                            'path' : ElementValue(string_value = 'mock_string_value'),
+                                            'params'(
+                                                list_value = 'action=cancel'
+                                                )
                                         }))
                     })
                 })
             }
         '''
         path_list_expected = ['mock_string_value']
-        replacement_dict_expected = {service: {"mock-key-1": ("put", "mock_string_value")}}
+        replacement_dict_expected = {service: {"mock-key-1": ("put", "mock_string_value?action=filter&action=cancel")}}
         replacement_dict_actual = {}
         service_type_actual, path_list_actual = dict_processing.get_paths_inside_metamodel(service,
                                                                                            service_dict,

--- a/test_rest_deprecation.py
+++ b/test_rest_deprecation.py
@@ -21,7 +21,7 @@ class TestRestDeprecationHandler(unittest.TestCase):
         self.rest_deprecation_handler.add_deprecation_information(path_obj, self.sample_package, self.sample_service)
 
         self.assertEqual(path_obj['deprecated'], True)
-        self.assertEqual(path_obj["x-vmw-deprecated"]["replacement"], "api_vcenter.json#/paths/~1rest~1vcenter~1vm/get")
+        self.assertEqual(path_obj["x-vmw-deprecated"]["replacement"], "api_vcenter.json#/paths/~1api~1rest~1vcenter~1vm/get")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This commit fixes the incorrect replacement path which is added to
depraceted operations when deprecation is enabled. The 'api' prefix
and the query params (apparent in the operation path) are added
to the replacement path.

Another small fix is a missing '-' in the input params.

Signed-off-by: Anton Obretenov <obretenova@vmware.com>