### PR TITLE
Added naive support for formData

### DIFF
--- a/lib/api_endpoint/api_metamodel2spec.py
+++ b/lib/api_endpoint/api_metamodel2spec.py
@@ -27,6 +27,7 @@ class ApiMetamodel2Spec():
             service_name,
             operation_name,
             params_metadata,
+            content_type,
             type_dict,
             structure_svc,
             enum_svc,
@@ -38,6 +39,7 @@ class ApiMetamodel2Spec():
                 service_name,
                 operation_name,
                 params_metadata,
+                content_type,
                 type_dict,
                 structure_svc,
                 enum_svc,
@@ -68,6 +70,7 @@ class ApiMetamodel2Spec():
             service_name,
             operation_name,
             params,
+            content_type,
             type_dict,
             structure_svc,
             enum_svc,
@@ -94,13 +97,17 @@ class ApiMetamodel2Spec():
             parx = spec.wrap_body_params(
                 service_name,
                 operation_name,
+                content_type,
                 body_param_list,
                 type_dict,
                 structure_svc,
                 enum_svc,
                 show_unreleased_apis)
             if parx is not None:
-                par_array.append(parx)
+                if isinstance(parx, list):
+                    par_array.extend(parx)
+                else:
+                    par_array.append(parx)
 
         # Query
         query_param_list, other_param_list = utils.extract_query_parameters(

--- a/lib/api_endpoint/oas3/api_openapi_parameter_handler.py
+++ b/lib/api_endpoint/oas3/api_openapi_parameter_handler.py
@@ -60,6 +60,7 @@ class ApiOpenapiParaHandler():
             self,
             service_name,
             operation_name,
+            content_type,
             body_param_list,
             type_dict,
             structure_svc,
@@ -74,6 +75,8 @@ class ApiOpenapiParaHandler():
         'spec' : {spec obj representation  }
         }
         """
+        # todo:
+        # form-url-encoded support; not utilized content_type
         # todo:
         # not unique enough. make it unique
         wrapper_name = utils.get_str_camel_case(service_name + '_' + operation_name, *utils.CAMELCASE_SEPARATOR_LIST)

--- a/lib/api_endpoint/swagger2/api_metamodel2swagger.py
+++ b/lib/api_endpoint/swagger2/api_metamodel2swagger.py
@@ -25,12 +25,15 @@ class ApiMetamodel2Swagger(ApiMetamodel2Spec):
             show_unreleased_apis):
         documentation = operation_info.documentation
         op_metadata = operation_info.metadata
+        method_info = op_metadata[http_method]
+        content_type = method_info.elements["consumes"].string_value if "consumes" in method_info.elements else None
+
         params = operation_info.params
         errors = operation_info.errors
         output = operation_info.output
         http_method = http_method.lower()
         par_array, url = self.handle_request_mapping(url, http_method, service_name,
-                                                     operation_id, params, type_dict,
+                                                     operation_id, params, content_type, type_dict,
                                                      structure_dict, enum_dict, show_unreleased_apis, api_swagg_ph)
         response_map = api_swagg_rh.populate_response_map(
             output,
@@ -44,6 +47,9 @@ class ApiMetamodel2Swagger(ApiMetamodel2Spec):
             op_metadata,
             show_unreleased_apis)
 
+        consumes = None
+        if content_type == 'FORM_URLENCODED':
+            consumes = ["application/x-www-form-urlencoded"]
         path_obj = utils.build_path(
             service_name,
             http_method,
@@ -51,7 +57,8 @@ class ApiMetamodel2Swagger(ApiMetamodel2Spec):
             documentation,
             par_array,
             operation_id=operation_id,
-            responses=response_map)
+            responses=response_map,
+            consumes=consumes)
         self.post_process_path(path_obj)
         path = utils.add_basic_auth(path_obj)
         return path

--- a/test_api_endpoint.py
+++ b/test_api_endpoint.py
@@ -251,9 +251,12 @@ class TestApiMetamodel2Spec(unittest.TestCase):
         ]
         '''
         spec = ApiSwaggerParaHandler()
-        par_array_actual, new_url_actual = self.api_meta2spec.process_put_post_patch_request(self.url, 'com.vmware.package.mock', 
-                                                                                        'mock_operation_name', params, 
-                                                                                        self.type_dict, {}, {}, False, spec)
+        par_array_actual, new_url_actual = self.api_meta2spec.process_put_post_patch_request(self.url,
+                                                                                             'com.vmware.package.mock',
+                                                                                             'mock_operation_name',
+                                                                                             params, None,
+                                                                                             self.type_dict, {}, {},
+                                                                                             False, spec)
         par_array_expected = [{
             'required': True,
             'in': 'path',
@@ -288,9 +291,12 @@ class TestApiMetamodel2Spec(unittest.TestCase):
         # case 2: create parameter array using field information of parameters for
         # put, post, patch operations in openAPI 3.0
         spec  = ApiOpenapiParaHandler()
-        par_array_actual, new_url_actual = self.api_meta2spec.process_put_post_patch_request(self.url, 'com.vmware.package.mock', 
-                                                                                        'mock_operation_name', params, 
-                                                                                        self.type_dict, {}, {}, False, spec)
+        par_array_actual, new_url_actual = self.api_meta2spec.process_put_post_patch_request(self.url,
+                                                                                             'com.vmware.package.mock',
+                                                                                             'mock_operation_name',
+                                                                                             params, None,
+                                                                                             self.type_dict, {}, {},
+                                                                                             False, spec)
         par_array_expected = [{
             'required': True,
             'in': 'path',

--- a/test_api_oas.py
+++ b/test_api_oas.py
@@ -68,9 +68,11 @@ class TestApiOpenapiParaHandler(unittest.TestCase):
             'ComVmwarePackageMock-1' : {}
         }
         body_param_list = [self.field_info_mock]
-        parameter_obj_actual = self.api_openapi_parahandler.wrap_body_params('com.vmware.package.mock-1', 'mockOperationName', 
-                                                                        body_param_list, type_dict, self.structure_dict, 
-                                                                        self.enum_dict, False)
+        parameter_obj_actual = self.api_openapi_parahandler.wrap_body_params('com.vmware.package.mock-1',
+                                                                             'mockOperationName', None,
+                                                                             body_param_list, type_dict,
+                                                                             self.structure_dict,
+                                                                             self.enum_dict, False)
         parameter_obj_expected = {'$ref': '#/components/requestBodies/ComVmwarePackageMock-1MockOperationName'}
         self.assertEqual(parameter_obj_expected, parameter_obj_actual)
         type_dict_expected = {

--- a/test_api_swagger.py
+++ b/test_api_swagger.py
@@ -57,15 +57,17 @@ class TestApiSwaggerParaHandler(unittest.TestCase):
         self.assertEqual(parameter_obj_expected, parameter_obj_actual)
 
     def test_wrap_body_params(self):
-        # validate parameter object by creating json wrappers around body object 
+        # validate parameter object by creating json wrappers around body object
         type_dict = {
             'com.vmware.package.mock': {},
             'ComVmwarePackageMock': {}
         }
         body_param_list = [self.field_info_mock]
-        parameter_obj_actual = self.api_swagger_parahandler.wrap_body_params('com.vmware.package.mock', 'mockOperationName', 
-                                                                           body_param_list, type_dict, self.structure_dict, 
-                                                                           self.enum_dict, False)         
+        parameter_obj_actual = self.api_swagger_parahandler.wrap_body_params('com.vmware.package.mock',
+                                                                             'mockOperationName', None,
+                                                                             body_param_list, type_dict,
+                                                                             self.structure_dict,
+                                                                             self.enum_dict, False)
         parameter_obj_expected = {
             'in': 'body',
             'name': 'request_body',
@@ -80,9 +82,11 @@ class TestApiSwaggerParaHandler(unittest.TestCase):
         metadata_mock.elements = {"name": element_value_mock}
 
         self.field_info_mock.metadata = {"BodyField": metadata_mock}
-        parameter_obj_actual = self.api_swagger_parahandler.wrap_body_params('com.vmware.package.mock', 'mockOperationName',
-                                                                           body_param_list, type_dict, self.structure_dict,
-                                                                           self.enum_dict, False)
+        parameter_obj_actual = self.api_swagger_parahandler.wrap_body_params('com.vmware.package.mock',
+                                                                             'mockOperationName', None,
+                                                                             body_param_list, type_dict,
+                                                                             self.structure_dict,
+                                                                             self.enum_dict, False)
         parameter_obj_expected = {
             'in': 'body',
             'name': 'request_body',
@@ -90,7 +94,36 @@ class TestApiSwaggerParaHandler(unittest.TestCase):
             'schema': {'$ref': '#/definitions/ComVmwarePackageMockMockOperationName'}
         }
         self.assertEqual(parameter_obj_expected, parameter_obj_actual)
-    
+
+    def test_wrap_form_data_params(self):
+        # validate parameter object by creating json wrappers around body object
+        type_dict = {
+            'ComVmwarePackageMockWrapper': {
+                "$ref": "#/definitions/ComVmwarePackageMock"
+            },
+            'ComVmwarePackageMock': {
+                "type": "string",
+                "properties": {
+                    "param_name": {
+                        "description": "my test name",
+                        "type": "string"
+                    }},
+                "required": [
+                    "param_name"
+                ]
+            }}
+        parameter_obj_actual = self.api_swagger_parahandler.wrap_form_data_params(type_dict,
+                                                                                  "ComVmwarePackageMockWrapper")
+        parameter_obj_expected = [{
+            'in': 'formData',
+            'name': 'param_name',
+            "description": "my test name",
+            "type": "string",
+            "required": "true"
+        }]
+
+        self.assertEqual(parameter_obj_expected, parameter_obj_actual)
+
     def test_flatten_query_param_spec(self):
         # case 1: parameter object takes reference from type_dict key
         # case 1.1: type dict reference value contains properties


### PR DESCRIPTION
Based on the operation info the content type is determined. If it is
FORM_URLENCODED, it is handled differetly, because of the specification
requirements.

The support is naive because a definition is created (as in the old
behavior), but rather pointing to a reference to that definition.
I am shallowly recursing through it and mapping it to a formData
dictionary.

A better solution is to extend the visitor pattern when creating
definitions and a support for FORM_URLENCODED, rather than creating
an unused definition. But, since this is a large effort, the naive
solution seems suitable.

Added tests and compared old and newly generated specifications.

NOTE - support only for swagger 2.0

Signed-off-by: Anton Obretenov <obretenova@vmware.com>