### PR TITLE
Bugfix/incorrect replacement path

### DIFF
--- a/lib/dictionary_processing.py
+++ b/lib/dictionary_processing.py
@@ -134,6 +134,9 @@ def add_service_urls_using_metamodel(
             for path in path_list:
                 service_urls_map[path] = (service, '/api')
                 package_name = path.split('/')[1]
+                # special handling for /api/sesion
+                if package_name == 'session':
+                    package_name = 'cis'
                 pack_arr = package_dict_api.get(package_name, [])
                 if pack_arr == []:
                     package_dict_api[package_name] = pack_arr
@@ -210,10 +213,13 @@ def get_paths_inside_metamodel(service,
 
                 if has_rest_counterpart:
                     url = path
-                    if 'params' in service_dict[service].operations[operation_id].metadata[request].elements:
-                        element_value = service_dict[service].operations[operation_id].metadata[request].elements['params']
+                    elems = service_dict[service].operations[operation_id].metadata[request].elements
+                    if 'params' in elems:
+                        element_value = elems['params']
                         params = "&".join(element_value.list_value)
                         url = path + '?' + params
+                    if operation_id.endswith('$task'):
+                        url = utils.add_query_param(url, 'vmw-task=true')
                     add_replacement_path(service, operation_id, request.lower(), url, replacement_dict)
 
                 if not has_rest_counterpart or deprecate_rest or blacklist_utils.is_blacklisted_for_rest(service):

--- a/lib/rest_endpoint/rest_deprecation_handler.py
+++ b/lib/rest_endpoint/rest_deprecation_handler.py
@@ -10,21 +10,27 @@ class RestDeprecationHandler:
         self.replacement_dict = replacement_dict
 
     def add_deprecation_information(self, path_obj, package_name, service_name):
-        replacement_path = "<unknown>"
-        path_obj["deprecated"] = True
-
-        # construct file name
-        api_file_name = "api_" + package_name + ".json"
-
+        method = None
+        new_path = None
         # Could be a more intelligent resolution - guessing based on key words?
         operation_map = self.replacement_dict.get(service_name)
         if operation_map is not None and "operationId" in path_obj:
             method_path_tuple = operation_map.get(path_obj["operationId"])
             if method_path_tuple is not None:
-                # get concrete path and format accordingly
-                replacement_path = method_path_tuple[1]
-                replacement_path = replacement_path.replace("/", "~1")
-                replacement_path = api_file_name + "#/paths/~1api" + replacement_path + "/" + method_path_tuple[0]
+                method = method_path_tuple[0]
+                new_path = method_path_tuple[1]
+
+        RestDeprecationHandler.add_deprecation_information_raw(path_obj, package_name, method, new_path)
+
+    @staticmethod
+    def add_deprecation_information_raw(path_obj, package_name, method, new_path):
+        replacement_path = "<unknown>"
+        path_obj["deprecated"] = True
+
+        # construct file name
+        api_file_name = package_name + ".json"
+
+        if method is not None and new_path is not None:
+            replacement_path = api_file_name + "#/paths/~1api" + new_path.replace("/", "~1") + "/" + method
 
         path_obj["x-vmw-deprecated"] = {"replacement": replacement_path}
-

--- a/lib/rest_endpoint/rest_metadata_processor.py
+++ b/lib/rest_endpoint/rest_metadata_processor.py
@@ -5,6 +5,7 @@ import os
 from lib import utils
 from lib.metadata_processor import MetadataProcessor
 from .oas3.rest_metamodel2openapi import RestMetamodel2Openapi
+from .rest_deprecation_handler import RestDeprecationHandler
 from .swagger2.rest_metamodel2swagger import RestMetamodel2Swagger
 
 swagg = RestMetamodel2Swagger()
@@ -82,8 +83,11 @@ class RestMetadataProcessor(MetadataProcessor):
                             http_error_map,
                             show_unreleased_apis)
 
-                    if deprecation_handler is not None and service_end_point == "/deprecated":
-                        deprecation_handler.add_deprecation_information(path, package_name, service_name)
+                    if deprecation_handler is not None:
+                        if operation_id == 'exchange' and service_name == 'com.vmware.vcenter.tokenservice.token_exchange':
+                            RestDeprecationHandler.add_deprecation_information_raw(path, package_name, 'post', '/vcenter/authentication/token')
+                        elif service_end_point == "/deprecated":
+                            deprecation_handler.add_deprecation_information(path, package_name, service_name)
                     path_list.append(path)
                 continue
             # use rest navigation service to get the REST mappings for a

--- a/test_rest_deprecation.py
+++ b/test_rest_deprecation.py
@@ -21,7 +21,7 @@ class TestRestDeprecationHandler(unittest.TestCase):
         self.rest_deprecation_handler.add_deprecation_information(path_obj, self.sample_package, self.sample_service)
 
         self.assertEqual(path_obj['deprecated'], True)
-        self.assertEqual(path_obj["x-vmw-deprecated"]["replacement"], "api_vcenter.json#/paths/~1api~1rest~1vcenter~1vm/get")
+        self.assertEqual(path_obj["x-vmw-deprecated"]["replacement"], "vcenter.json#/paths/~1api~1rest~1vcenter~1vm/get")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
    [VAPI-4801] Fix deprecation links in the api-explorer
    
    This change fixes the following three issues:
    1. /api/session is not linked to /rest/com/vmware/cis/session (due to the lack
       of /cis in the new representation)
    2. vmw-task=true (i.e. @TaskOnly) operations are not linked properly
    3. the new token-exchange is not linked to the old one (there is no metadata
       for that link)
    
    It also fixes the filename used in the deprecation path by removing the
    'api_' prefix. This doesn't affect the api-explorer in any way.
    
    Testing done: switched the 3 affected files on a deployment and verified
    that operations are now properly linked.
