### PR TITLE
Fix missing argument, Set content_type in handle_request_mapping

### DIFF
--- a/lib/api_endpoint/oas3/api_metamodel2openapi.py
+++ b/lib/api_endpoint/oas3/api_metamodel2openapi.py
@@ -25,12 +25,15 @@ class ApiMetamodel2Openapi(ApiMetamodel2Spec):
             show_unreleased_apis):
         documentation = operation_info.documentation
         op_metadata = operation_info.metadata
+        method_info = op_metadata[http_method]
+        content_type = method_info.elements["consumes"].string_value if "consumes" in method_info.elements else None
+
         params = operation_info.params
         errors = operation_info.errors
         output = operation_info.output
         http_method = http_method.lower()
         par_array, url = self.handle_request_mapping(url, http_method, service_name,
-                                                     operation_id, params, type_dict,
+                                                     operation_id, params, content_type, type_dict,
                                                      structure_dict, enum_dict, show_unreleased_apis, api_open_ph)
         response_map = api_open_rh.populate_response_map(
             output,


### PR DESCRIPTION
fixed: #70 

`lib.api_endpoint.api_metamodel2spec.handle_request_mapping` needs `content_type` argument, but it's missing. https://github.com/vmware/vmware-openapi-generator/blob/54cf631512e69ca731a1fd5c0662b647833e7e2d/lib/api_endpoint/oas3/api_metamodel2openapi.py#L32-L34

This commit adds `content_type` argument.
So I can complete generating.

Signed-off-by: whywaita <whywaita@whywrite.it>